### PR TITLE
Rework campaignion_google_analytics JavaScript

### DIFF
--- a/campaignion_google_analytics/campaignion_google_analytics.module
+++ b/campaignion_google_analytics/campaignion_google_analytics.module
@@ -20,49 +20,162 @@ function _campaignion_google_analytics_load_payment($nid, $sid) {
   }
 }
 
+
+function _campaignion_google_analytics_is_donation_page($node) {
+  // TODO better check whether the node type is a donation
+  return ($node->type == 'donation' || $node->type == 'donation2' || $node->type == 'sponsorship');
+}
+
 /**
  * Implements hook_init().
  */
-
 function campaignion_google_analytics_node_view($node, $view_mode, $langcode) {
-  // TODO better check whether the node type is a donation
-  if ($node->type == 'donation' || $node->type == 'donation2' || $node->type == 'sponsorship') {
+  if (_campaignion_google_analytics_is_donation_page($node)) {
+    drupal_add_js(drupal_get_path('module', 'campaignion_google_analytics') . '/tracking.js');
     drupal_add_js(drupal_get_path('module', 'campaignion_google_analytics') . '/donation.js');
 
-    $webform = Webform::fromNode($node);
-    $paymethod = $webform->componentByKey('paymethod_select');
-    $currency_code = isset($paymethod['extra']['currency_code']) ? $paymethod['extra']['currency_code'] : 'EUR';
-    // add view resp. impressions keys to control which events will be
-    // sent to GA
-    if ($view_mode == 'full') {
-      drupal_add_js(
-        array(
-          'campaignion_google_analytics' => array(
-            'view' => array(
-              'nid' => $node->nid,
-              'title' => $node->title,
-              'lang' => $node->language,
-              'currency' => $currency_code,
-            ),
-          ),
+    // general informatio about the node
+    drupal_add_js(
+      array(
+        'campaignion_google_analytics' => array(
+          'nid' => $node->nid,
+          'language' => $node->language,
+          'title' => $node->title,
+          'actions' => [],
         ),
-        'setting');
-    }
+      ),
+      'setting');
+    // add impressions keys to control which events will be
     if ($view_mode == 'teaser') {
+      // current_path ist always set, but menu_get_object() may not return a
+      // node object every time, e.g. when on a view
+      $path = current_path();
+      if ($parentnode = menu_get_object()) {
+        $list = $parentnode->title . ' [' . $path . ']';
+      } else {
+        $list = '[' . $path . ']';
+      }
+
       drupal_add_js(
         array(
           'campaignion_google_analytics' => array(
-            'impressions' => array(
-              strval($node->nid) => array(
-                'nid' => $node->nid,
-                'title' => $node->title,
-                'lang' => $node->language,
+            'actions' => ['impression'],
+            // an impression object
+            'impression' => array(
+              // need to prefix index, otherwise "deduplicating" the
+              // impressions would not work... (same php indexes would simply
+              // be appended in JavaScript, propably because of PHP numeric
+              // array key behaviour
+              'nid-' . $node->nid => array(
+                'id' => $node->nid,
+                'name' => $node->title . " [" . $node->language . "]",
+                'list' => $list
               ),
             ),
           ),
         ),
         'setting');
     }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function campaignion_google_analytics_form_webform_client_form_alter(&$form, &$form_state, $form_id) {
+  $node = $form['#node'];
+  if (_campaignion_google_analytics_is_donation_page($node)) {
+    $donation_title = $node->title;
+    $donation_lang = $node->language;
+
+    $webform = Webform::fromNode($form['#node']);
+    $submission = $webform->formStateToSubmission($form_state);
+    $paymethod = $webform->componentByKey('paymethod_select');
+    $currency_code = isset($paymethod['extra']['currency_code']) ? $paymethod['extra']['currency_code'] : 'EUR';
+
+    $interval = '';
+    switch ($submission->valueByKey('donation_interval')) {
+    case '1':
+      $interval = 'only once';
+      break;
+    case 'm':
+      $interval = 'monthly';
+      break;
+    case 'y':
+      $interval = 'yearly';
+      break;
+    default:
+      $interval = "unknown [" . $submission->valueByKey('donation_interval') . "]";
+    }
+
+    $amount = intval($submission->valueByKey('donation_amount'));
+
+    $ga_product_name = $donation_title . ' [' . $donation_lang . ']';
+    // add common product properties
+    drupal_add_js(
+      array(
+        'campaignion_google_analytics' => array(
+          'actions' => [], // reset action
+          'currency' => $currency_code,
+          'product' => array(
+            'id' => $node->nid,
+            'name' => $ga_product_name,
+          ))),
+      'setting');
+    // merge specific product into common properties depending on step
+    // we define the view with the 1st step
+    if ($form_state['webform']['page_num'] == 1) {
+      drupal_add_js(
+        array(
+          'campaignion_google_analytics' => array(
+            'actions' => ['view'],
+            'product' => array(
+            ))),
+        'setting');
+    }
+    // we define the add to cart with completion of the 1st step, usually this
+    // means we have successfully selected the amount and interval
+    if ($form_state['webform']['page_num'] == 2) {
+      drupal_add_js(
+        array(
+          'campaignion_google_analytics' => array(
+            'actions' => ['add'],
+            'product' => array(
+              'price' => $amount,
+              'category' => $interval,
+              'quantity' => '1',
+          ))),
+        'setting');
+    }
+    // we define the checkout begin with the *completion* of the 2nd step or
+    // with the last step
+    if ($form_state['webform']['page_num'] == 3 || $form_state['webform']['page_num'] == $form_state['webform']['page_count']) {
+      drupal_add_js(
+        array(
+          'campaignion_google_analytics' => array(
+            'actions' => ['checkoutBegin'],
+            'product' => array(
+              'price' => $amount,
+              'category' => $interval,
+              'quantity' => '1',
+          ))),
+        'setting');
+    }
+    // we define the checkout end with the last step
+    if ($form_state['webform']['page_num'] == $form_state['webform']['page_count']) {
+      drupal_add_js(
+        array(
+          'campaignion_google_analytics' => array(
+            'actions' => ['checkoutEnd'],
+            'product' => array(
+              'price' => $amount,
+              'category' => $interval,
+              'quantity' => '1',
+          ))),
+        'setting');
+    }
+    // the purchase has to be on the thanlyou page, because only there we can
+    // be sure whether the payment was successful
   }
 }
 
@@ -81,13 +194,17 @@ function campaignion_google_analytics_page_build(&$page) {
   $node = $submission->getNode();
 
   // as long as share and sid are there, we are on a thank you page.
-  drupal_add_js(array('campaignion_google_analytics' => array(
-        'thank_you' => True,
+  // general informatio about the node
+  drupal_add_js(
+    array(
+      'campaignion_google_analytics' => array(
         'nid' => $node->nid,
+        'language' => $node->language,
         'title' => $node->title,
-        'lang' => $node->language,
-      )), 'setting');
-
+        'actions' => [],
+      ),
+    ),
+    'setting');
 
   if ($payment = _campaignion_google_analytics_load_payment($nid, $sid)) {
     $donation_title = $node->title;
@@ -103,20 +220,31 @@ function campaignion_google_analytics_page_build(&$page) {
     case 'y':
       $interval = 'yearly';
       break;
+    default:
+      $interval = "unknown [" . $submission->valueByKey('donation_interval') . "]";
     }
     $ga_product_name = $donation_title . ' [' . $donation_lang . ']';
+    $amount = $payment->totalAmount(false);
+
     drupal_add_js(
       array(
         'campaignion_google_analytics' => array(
-          'payment' => array(
-            'id' => $payment->pid,
+          'actions' => ['purchase'],
+          'product' => array(
+            'id' => $node->nid,
             'name' => $ga_product_name,
-            'price' => $payment->totalAmount(false),
+            'price' => $amount,
             'category' => $interval,
             'currency' => $payment->currency_code,
             'quantity' => '1',
-          ))),
+          ),
+          'purchase' => array(
+            'id' => $payment->pid,
+            'revenue' => $amount,
+            'currency' => $payment->currency_code,
+        ))),
       'setting');
   }
+  drupal_add_js(drupal_get_path('module', 'campaignion_google_analytics') . '/tracking.js');
   drupal_add_js(drupal_get_path('module', 'campaignion_google_analytics') . '/thank_you_page.js');
 }

--- a/campaignion_google_analytics/thank_you_page.js
+++ b/campaignion_google_analytics/thank_you_page.js
@@ -1,38 +1,23 @@
 (function($) {
     Drupal.behaviors.campaignion_google_analytics = {};
     Drupal.behaviors.campaignion_google_analytics.attach = function(context, settings) {
-        if (typeof ga === 'undefined') { return; }
         var config =  settings.campaignion_google_analytics;
-        if (typeof config !== 'undefined') {
-            if (typeof config.thank_you !== "undefined") {
-                ga("send", "event", "webform", "submitted", config.title+" ["+config.nid+"]");
-            }
-            if (typeof config.payment !== 'undefined') {
-              if (sessionStorage.getItem('sentDonationPurchase-'+config.nid) !== '1') {
-                ga('require', 'ec');
-                ga('set', '&cu',  config.payment.currency);
-                ga('ec:addProduct', {
-                  id: config.nid,
-                  name: config.title + " ["+config.lang+"]",
-                  price: config.payment.price,
-                  category: config.payment.category,
-                  quantity: 1
-                });
-                ga('ec:setAction', 'purchase',  {
-                  id: config.payment.id,
-                  currency: config.payment.currency,
-                  revenue: config.payment.price
-                });
-                ga("send", "event", "donation", "purchase", config.title+" ["+config.nid+"]");
+        if (typeof config === "undefined") {
+          return
+        }
 
-                sessionStorage.setItem('sentDonationPurchase-'+config.nid, '1');
-                // reset state
-                sessionStorage.removeItem('sentDonationCheckoutBegin-'+config.nid);
-                sessionStorage.removeItem('sentDonationCheckoutLast-'+config.nid);
-                sessionStorage.removeItem('sentDonationView-'+config.nid);
-                sessionStorage.removeItem('sentDonationAdd-'+config.nid);
-              }
-            }
+        var tracker = new tracking.Tracker({defaultCurrency: 'EUR'});
+        tracker.initializeDonation();
+
+        var actions = config.actions;
+
+        tracker.ga("send", "event", "webform", "submitted", config.title + " [" + config.nid + "]");
+
+        if (actions.indexOf('purchase') >= 0) {
+          tracker.initializeDonation({ currency: config.currency });
+          tracker.sendPurchase(config.product, { eventLabel: config.title + " [" + config.nid + "]"}, config.purchase);
+          // clear state after, as we are done sending
+          delete actions[actions.indexOf('purchase')];
         }
     }
 })(jQuery);

--- a/campaignion_google_analytics/tracking.js
+++ b/campaignion_google_analytics/tracking.js
@@ -1,0 +1,538 @@
+/**
+ * mo-tracking - A tracking module.
+ * @version v0.1.0
+ * @link https://github.com/moreonion/tracking
+ * @license AGPL-3.0
+ */
+(function (global, factory) {
+    if (typeof define === "function" && define.amd) {
+        define(['exports'], factory);
+    } else if (typeof exports !== "undefined") {
+        factory(exports);
+    } else {
+        var mod = {
+            exports: {}
+        };
+        factory(mod.exports);
+        global.tracking = mod.exports;
+    }
+})(this, function (exports) {
+    'use strict';
+
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    exports.Tracker = Tracker;
+
+    var _extends = Object.assign || function (target) {
+        for (var i = 1; i < arguments.length; i++) {
+            var source = arguments[i];
+
+            for (var key in source) {
+                if (Object.prototype.hasOwnProperty.call(source, key)) {
+                    target[key] = source[key];
+                }
+            }
+        }
+
+        return target;
+    };
+
+    /* global window global */
+    /**
+     * Tracking module.
+     *
+     * @module tracking
+     */
+
+    var root;
+    if (typeof window !== 'undefined') {
+        root = window;
+    } else if (typeof global !== 'undefined') {
+        root = global;
+    } else {
+        root = {};
+    }
+
+    var MARKED_VALUE = '1';
+    var UNMARKED_VALUE = '0';
+
+    /**
+     * Creates a Tracker instance.
+     *
+     * @constructor
+     * @this {Tracker}
+     * @param {object} [options] - the options
+     * @param {string} [options.root=window|global|{}] - the root object<br>
+     *     Per default tries to set this to <code>window</code> (Browsers),
+     *     <code>global</code> (nodejs), or an empty object <code>{}</code>.
+     * @param {string} [options.gaFnName='ga'] - Google Analytics command queue
+     *     function name
+     * @param {string} [options.uniqueEvents=true] - send events only once
+     * @param {function}
+     *     [options.storageIdentifierFn=this.defaultStorageIdentifierFn] - function to
+     *     determine the storage identifier of an action<br>
+     *     <br>
+     *     The <code>storageIdentifierFn</code> needs at least an
+     *     <code>actionName</code> (string) as first parameter. Optional parameter
+     *     object which can be used in determining the storage key are:
+     *     <code>object</code>, <code>event</code>, and <code>action</code>.
+     * @param {function} [options.uniquifyFn=this.defaultUniquifyingFn] - function to
+     *     determine if something should count as unique compared to the.<br>
+     *     Default is to use <code>window.location.pathname</code>
+     * @param {string} [options.storage='local'] - the storage to use, for now<br>
+     *     This could be <code>local</code> for <code>root.localStorage</code> or
+     *     <code>session</code> for <code>root.sessionStorage</code>
+     * @param {object} [options.eventDefaults={}] - the default event
+     * @param {string} [options.eventDefaults.hitType='event'] - the default hit type
+     * @param {string} [options.eventDefaults.eventCategory] - the default event category
+     * @param {string} [options.eventDefaults.eventAction] - the default event action
+     * @param {string} [options.eventDefaults.eventLabel] - the default event label
+     * @param {number} [options.eventDefaults.eventValue] - the default event value
+     * @param {string} [options.defaultCurrency='EUR'] - the default currency for enhanced ecommerce
+     * @public
+     * @todo make storage customizable with own implementation
+     * @todo factor out storage into own module
+     * @todo check for window.GoogleAnalyticsObject to set gaFnName
+     * @todo load from storage on a possible second page/step?
+     */
+    function Tracker(options) {
+        /**
+         * The default settings.
+         * @var {object}
+         * @inner
+         */
+        var defaults = {
+            root: root,
+            gaFnName: 'ga',
+            storage: 'local',
+            defaultCurrency: 'EUR',
+            storageIdentifierFn: this.defaultStorageIdentifierFn,
+            uniquifyFn: this.defaultUniquifyingFn,
+            uniqueEvents: true,
+            eventDefaults: {
+                hitType: 'event'
+            }
+        };
+
+        /**
+         * The active settings.
+         * @member {object} settings
+         * @instance
+         * @memberof module:tracking~Tracker
+         */
+        this.settings = _extends(defaults, options);
+
+        /**
+         * The state storage to use.
+         *
+         * Can be `localStorage` or `sessionStorage`
+         *
+         * @member {Storage} storage to use
+         * @instance
+         * @memberof module:tracking~Tracker
+         * @todo add storage `cookie`
+         */
+        this.storage = null;
+
+        if (this.settings.storage === 'local') {
+            this.storage = this.settings.root['localStorage'];
+        }
+        if (this.settings.storage === 'session') {
+            this.storage = this.settings.root['sessionStorage'];
+        }
+
+        /**
+         * The Google Analytics command queue to use
+         *
+         * @member {function} ga() to use
+         * @instance
+         * @memberof module:tracking~Tracker
+         */
+        this.ga = null;
+        if (this._checkGA()) {
+            this.ga = this.settings.root[this.settings.gaFnName];
+        } else {
+            console.error('Tracker: "' + this.settings.gaFnName + '" is not defined yet or not a function'); // eslint-disable-line no-console
+        }
+    }
+
+    /**
+     * Check whether the Google Analytics queue function is available
+     *
+     * @private
+     * @returns {boolean}
+     */
+    Tracker.prototype._checkGA = function () {
+        return typeof this.settings.root[this.settings.gaFnName] === 'function';
+    };
+
+    /**
+     * Ensure the plugin is loaded.
+     *
+     * @private
+     */
+    Tracker.prototype._ensurePlugin = function () {
+        var name = arguments.length <= 0 || arguments[0] === undefined ? 'ec' : arguments[0];
+
+        this.ga('require', name);
+    };
+
+    /**
+     * Set basic properties for donation.
+     *
+     * @param {object} [options] - the options
+     * @param {string} [options.defaultCurrency='EUR'] - the default currency for enhanced ecommerce
+     */
+    Tracker.prototype.initializeDonation = function (options) {
+        var defaults = {
+            currency: this.settings.defaultCurrency
+        };
+        var settings = _extends(defaults, options);
+        this._ensurePlugin('ec');
+        this.ga('set', '&cu', settings.currency);
+    };
+
+    /**
+     * Validate an object.
+     *
+     * @param {string} [type='event'] - the type to validate against<br>
+     *     Can be on of: <code>event</code>, <code>impression</code>,
+     *     <code>product</code>, <code>action</action>, or <code>purchase</code>.
+     * @param {object} [object={}] - the object to validate
+     * @private
+     * @see https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference
+     */
+    Tracker.prototype._validateObject = function () {
+        var type = arguments.length <= 0 || arguments[0] === undefined ? 'event' : arguments[0];
+        var object = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+        // check if we really get an object to validate against
+        if (typeof object !== 'object' || object === null) {
+            return false;
+        }
+
+        // initialize
+        var success = true;
+        var oneOfAttributesRequired = [];
+        var allAttributesRequired = [];
+
+        // setup requirements
+        if (type === 'event') {
+            // see https://developers.google.com/analytics/devguides/collection/analyticsjs/events#event_fields
+            allAttributesRequired = ['eventCategory', 'eventAction'];
+        } else if (type === 'impression' || type === 'product') {
+            // see https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#impression-data
+            // https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#product-data
+            oneOfAttributesRequired = ['id', 'name'];
+        } else if (type === 'action') {
+            success = true;
+        } else if (type === 'purchase') {
+            // see https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#action-data
+            allAttributesRequired = ['id'];
+        }
+
+        if (oneOfAttributesRequired.length > 0) {
+            // one-of needs reverted start state (false)
+            success = false;
+            oneOfAttributesRequired.forEach(function (el) {
+                if (el in object) {
+                    success = true;
+                }
+            });
+        }
+        allAttributesRequired.forEach(function (el) {
+            success = success && el in object;
+        });
+
+        return success;
+    };
+
+    /**
+     * Send an impression.
+     *
+     * @param {impressionFieldObject} [object] - the
+     *     <code>impressionFieldObject</code> to send
+     * @param {event} [object] - the event to send
+     */
+    Tracker.prototype.sendImpression = function (impression) {
+        var event = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+        var ev = _extends(this.settings.eventDefaults, {
+            eventCategory: 'donation',
+            eventAction: 'impression'
+        });
+        var donationEvent = _extends(ev, event);
+        if (this._validateObject('impression', impression) && this._validateObject('event', donationEvent)) {
+            if (this.settings.uniqueEvents && !this.isSent('impression', impression, donationEvent)) {
+                this.ga('ec:addImpression', impression);
+                this.ga('send', donationEvent);
+                this.markSent('impression', impression, donationEvent);
+            }
+        } else {
+            console.error('Tracker: not a valid impressionFieldObject and/or event.'); // eslint-disable-line no-console
+        }
+    };
+
+    /**
+     * Send a detail view.
+     *
+     * @param {productFieldObject} [object] - the
+     *     <code>productFieldObject</code> to send
+     * @param {event} [object] - the event to send
+     */
+    Tracker.prototype.sendView = function (product) {
+        var event = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+        var ev = _extends(this.settings.eventDefaults, {
+            eventCategory: 'donation',
+            eventAction: 'view'
+        });
+        var donationEvent = _extends(ev, event);
+        if (this._validateObject('product', product) && this._validateObject('event', donationEvent)) {
+            if (this.settings.uniqueEvents && !this.isSent('view', product, donationEvent)) {
+                this.ga('ec:addProduct', product);
+                this.ga('ec:setAction', 'detail');
+                this.ga('send', donationEvent);
+                this.markSent('view', product, donationEvent);
+            }
+        } else {
+            console.error('Tracker: not a valid productFieldObject and/or event.'); // eslint-disable-line no-console
+        }
+    };
+
+    /**
+     * Send a product add.
+     *
+     * @param {productFieldObject} [object] - the
+     *     <code>productFieldObject</code> to send
+     * @param {event} [object] - the event to send
+     */
+    Tracker.prototype.sendAdd = function (product) {
+        var event = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+        var ev = _extends(this.settings.eventDefaults, {
+            eventCategory: 'donation',
+            eventAction: 'add to cart'
+        });
+        var donationEvent = _extends(ev, event);
+        if (this._validateObject('product', product) && this._validateObject('event', donationEvent)) {
+            if (this.settings.uniqueEvents && !this.isSent('add', product, donationEvent)) {
+                this.ga('ec:addProduct', product);
+                this.ga('ec:setAction', 'add');
+                this.ga('send', donationEvent);
+                this.markSent('add', product, donationEvent);
+            }
+        } else {
+            console.error('Tracker: not a valid productFieldObject and/or event.'); // eslint-disable-line no-console
+        }
+    };
+
+    /**
+     * Send a checkout begin.
+     *
+     * @param {productFieldObject} [object] - the
+     *     <code>productFieldObject</code> to send
+     * @param {event} [object] - the event to send
+     * @param {action} [object] - the action parameters
+     */
+    Tracker.prototype.sendBeginCheckout = function (product) {
+        var event = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+        var action = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+
+        var ev = _extends(this.settings.eventDefaults, {
+            eventCategory: 'donation',
+            eventAction: 'checkout'
+        });
+        var donationEvent = _extends(ev, event);
+        var actionDefaults = {
+            step: 1
+        };
+        var checkoutAction = _extends(actionDefaults, action);
+        if (this._validateObject('product', product) && this._validateObject('event', donationEvent) && this._validateObject('action', checkoutAction)) {
+            if (this.settings.uniqueEvents && !this.isSent('checkoutBegin', product, donationEvent, checkoutAction)) {
+                this.ga('ec:addProduct', product);
+                this.ga('ec:setAction', 'checkout', checkoutAction);
+                this.ga('send', donationEvent);
+                this.markSent('checkoutBegin', product, donationEvent, checkoutAction);
+            }
+        } else {
+            console.error('Tracker: not a valid productFieldObject and/or event and/or checkout action.'); // eslint-disable-line no-console
+        }
+    };
+
+    /**
+     * Send a checkout end.
+     *
+     * @param {productFieldObject} [object] - the
+     *     <code>productFieldObject</code> to send
+     * @param {event} [object] - the event to send
+     * @param {action} [object] - the action parameters
+     */
+    Tracker.prototype.sendEndCheckout = function (product) {
+        var event = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+        var action = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+
+        var ev = _extends(this.settings.eventDefaults, {
+            eventCategory: 'donation',
+            eventAction: 'checkout'
+        });
+        var donationEvent = _extends(ev, event);
+        var actionDefaults = {
+            step: 2
+        };
+        var checkoutAction = _extends(actionDefaults, action);
+        if (this._validateObject('product', product) && this._validateObject('event', donationEvent) && this._validateObject('action', checkoutAction)) {
+            if (this.settings.uniqueEvents && !this.isSent('checkoutEnd', product, donationEvent, checkoutAction)) {
+                this.ga('ec:addProduct', product);
+                this.ga('ec:setAction', 'checkout', checkoutAction);
+                this.ga('send', donationEvent);
+                this.markSent('checkoutEnd', product, donationEvent, checkoutAction);
+            }
+        } else {
+            console.error('Tracker: not a valid productFieldObject and/or event and/or checkout action.'); // eslint-disable-line no-console
+        }
+    };
+
+    /**
+     * Send a purchase.
+     *
+     * @param {productFieldObject} [object] - the
+     *     <code>productFieldObject</code> to send
+     * @param {event} [object] - the event to send
+     * @param {action} [object] - the action parameters
+     */
+    Tracker.prototype.sendPurchase = function (product) {
+        var event = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+        var action = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+
+        var ev = _extends(this.settings.eventDefaults, {
+            eventCategory: 'donation',
+            eventAction: 'purchase'
+        });
+        var donationEvent = _extends(ev, event);
+        var actionDefaults = {
+            currency: this.settings.defaultCurrency
+        };
+        var purchaseAction = _extends(actionDefaults, action);
+        if (this._validateObject('product', product) && this._validateObject('event', donationEvent) && this._validateObject('purchase', purchaseAction)) {
+            if (this.settings.uniqueEvents && !this.isSent('purchase', product, donationEvent, purchaseAction)) {
+                this.ga('ec:addProduct', product);
+                this.ga('ec:setAction', 'purchase', purchaseAction);
+                this.ga('send', donationEvent);
+                this.markSent('purchase', product, donationEvent, purchaseAction);
+            }
+        } else {
+            console.error('Tracker: not a valid productFieldObject and/or event and/or purchase action.'); // eslint-disable-line no-console
+        }
+    };
+
+    /**
+     * Default uniquifiying function.
+     *
+     * @returns {string}
+     */
+    Tracker.prototype.defaultUniquifyingFn = function () {
+        if ('location' in root) {
+            return root.location.pathname;
+        }
+    };
+
+    /**
+     * Default storage identifier function.
+     *
+     * @param {string} actionName - the action name
+     * @param {object} [object={}] - the object, i.e. product, impression
+     * @returns {string}
+     */
+    Tracker.prototype.defaultStorageIdentifierFn = function (actionName) {
+        var object = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+        var prefix = this.settings.uniquifyFn.call(this);
+        var objectId = typeof object.id === 'undefined' ? '' : object.id;
+        return prefix + '::' + actionName + '::' + objectId;
+    };
+
+    /**
+     * Check if an action was sent.
+     *
+     * @param {string} actionName - the action to check
+     * @param {object} [object={}] - the object, i.e. product, impression
+     * @param {event} [event={}] - the event parameters
+     * @param {action} [action={}] - the action parameters
+     * @returns {boolean}
+     */
+    Tracker.prototype.isSent = function (actionName) {
+        var object = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+        var event = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+        var action = arguments.length <= 3 || arguments[3] === undefined ? {} : arguments[3];
+
+        var identifier = this.settings.storageIdentifierFn.call(this, actionName, object, event, action);
+        var val = this.storage.getItem(identifier);
+        if (val === MARKED_VALUE) {
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    /**
+     * Mark an action as sent.
+     *
+     * @param {string} actionName - the action to mark sent
+     * @param {object} [object={}] - the object, i.e. product, impression
+     * @param {event} [event={}] - the event parameters
+     * @param {action} [action={}] - the action parameters
+     */
+    Tracker.prototype.markSent = function (actionName) {
+        var object = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+        var event = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+        var action = arguments.length <= 3 || arguments[3] === undefined ? {} : arguments[3];
+
+        var identifier = this.settings.storageIdentifierFn.call(this, actionName, object, event, action);
+        this.storage.setItem(identifier, MARKED_VALUE);
+    };
+
+    /**
+     * Unmark an action as sent.
+     *
+     * @param {string} actionName - the action to unmark sent
+     * @param {object} [object={}] - the object, i.e. product, impression
+     * @param {event} [event={}] - the event parameters
+     * @param {action} [action={}] - the action parameters
+     */
+    Tracker.prototype.unmarkSent = function (actionName) {
+        var object = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+        var event = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+        var action = arguments.length <= 3 || arguments[3] === undefined ? {} : arguments[3];
+
+        var identifier = this.settings.storageIdentifierFn.call(this, actionName, object, event, action);
+        this.storage.setItem(identifier, UNMARKED_VALUE);
+    };
+
+    /**
+     * Remove an action state from storage.
+     *
+     * @param {string} actionName - the action state to remove
+     * @param {object} [object={}] - the object, i.e. product, impression
+     * @param {event} [event={}] - the event parameters
+     * @param {action} [action={}] - the action parameters
+     */
+    Tracker.prototype.removeSent = function (actionName) {
+        var object = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+        var event = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+        var action = arguments.length <= 3 || arguments[3] === undefined ? {} : arguments[3];
+
+        var identifier = this.settings.storageIdentifierFn.call(this, actionName, object, event, action);
+        this.storage.removeItem(identifier);
+    };
+
+    /**
+     * Reset the storage.
+     */
+    Tracker.prototype.resetStorage = function () {
+        this.storage.clear();
+    };
+
+    // vim: set et ts=4 sw=4 :
+});


### PR DESCRIPTION
- refactored tracking calls into own library `tracking.js`
- adapted `donation.js` and `thank_you_page.js` for new library
- changed config object structure and flow for `Drupal.settings.campaignion_google_analytics`
- the objects in `Drupal.settings.campaignion_google_analytics` can now be passed as-is into a `ga()` call as event object
- add `list` paramter to impression object
- the interval is now sent already on the `add` action (was on `purchase` before)
- small fixes
- all JavaScript is ES5
