### PR TITLE
Action & Action type refactoring

### DIFF
--- a/campaignion_action/campaignion_action.api.php
+++ b/campaignion_action/campaignion_action.api.php
@@ -10,16 +10,19 @@ use \Drupal\little_helpers\Webform\Submission;
 
 /**
  * @return array
- *   class names indexed by (machine readable) content-type names
+ *   Config arrays indexed by (machine readable) content-type names:
+ *     - class: The type class representing actions of this type.
+ *       Defaults to \Drupal\campiagnion_action\TypeBase
+ *     - parameters: For backwards compatibility. The values are merged into
+ *       The main array.
+ *     The whole config array is passed as $parameters to the class constructor.
  */
 function hook_campaignion_action_info() {
   $types['webform'] = array(
     'class' => 'Drupal\\campaignion_action\\FlexibleForm',
-    'parameters' => array(
-      'thank_you_page' => array(
-        'type' => 'thank_you_page',
-        'reference' => 'field_thank_you_pages',
-      ),
+    'thank_you_page' => array(
+      'type' => 'thank_you_page',
+      'reference' => 'field_thank_you_pages',
     ),
   );
   return $types;

--- a/campaignion_action/src/ActionBase.php
+++ b/campaignion_action/src/ActionBase.php
@@ -6,6 +6,10 @@ class ActionBase {
   protected $type;
   protected $node;
 
+  public static function fromTypeAndNode(TypeInterface $type, $node) {
+    return new static($type, $node);
+  }
+
   public function __construct(TypeInterface $type, $node) {
     $this->type = $type;
     $this->node = $node;

--- a/campaignion_action/src/ActionBase.php
+++ b/campaignion_action/src/ActionBase.php
@@ -9,7 +9,6 @@ class ActionBase {
   public function __construct(TypeInterface $type, $node) {
     $this->type = $type;
     $this->node = $node;
-    $this->node->action = $this;
   }
 
   /**

--- a/campaignion_action/src/Loader.php
+++ b/campaignion_action/src/Loader.php
@@ -92,9 +92,13 @@ class Loader {
    * Get action instance by node-type.
    */
   public function actionFromNode($node) {
-    if ($type = $this->type($node->type)) {
-      return $type->actionFromNode($node);
+    if (!isset($node->action)) {
+      $node->action = NULL;
+      if ($type = $this->type($node->type)) {
+        $node->action = $type->actionFromNode($node);
+      }
     }
+    return $node->action;
   }
 
   /**

--- a/campaignion_action/src/Loader.php
+++ b/campaignion_action/src/Loader.php
@@ -26,7 +26,10 @@ class Loader {
 
   public function __construct($types_info) {
     foreach ($types_info as $type => &$info) {
-      $info += array('parameters' => array());
+      $info += [
+        'class' => '\\Drupal\\campaignion_action\\TypeBase',
+        'parameters' => [],
+      ];
     }
     $this->info = $types_info;
     $this->types = &drupal_static(__CLASS__ . '::types', []);

--- a/campaignion_action/src/Loader.php
+++ b/campaignion_action/src/Loader.php
@@ -99,7 +99,7 @@ class Loader {
       $node->action = NULL;
       if ($type = $this->type($node->type)) {
         $class = $this->info[$node->type]['action_class'];
-        $node->action = $class::fromTypeAnyNode($type, $node);
+        $node->action = $class::fromTypeAndNode($type, $node);
       }
     }
     return $node->action;

--- a/campaignion_action/src/Loader.php
+++ b/campaignion_action/src/Loader.php
@@ -98,10 +98,30 @@ class Loader {
     if (!isset($node->action)) {
       $node->action = NULL;
       if ($type = $this->type($node->type)) {
-        $node->action = $type->actionFromNode($node);
+        $class = $this->info[$node->type]['action_class'];
+        $node->action = $class::fromTypeAnyNode($type, $node);
       }
     }
     return $node->action;
+  }
+
+  /**
+   * Return a wizard object for a node-type.
+   *
+   * @param string $type
+   *   The node-type.
+   * @param object|null $node
+   *   The node to edit. Create a new one if NULL.
+   *
+   * @return \Drupal\oowizard\Wizard
+   *  The wizard responsible for changing/adding actions of this type.
+   */
+  public function wizard($type, $node = NULL) {
+    if ($type_o = $this->type($type)) {
+      $info = $this->info[$type];
+      $class = $info['wizard_class'];
+      return new $class($info, $node, $type_o);
+    }
   }
 
   /**

--- a/campaignion_action/src/Loader.php
+++ b/campaignion_action/src/Loader.php
@@ -85,7 +85,7 @@ class Loader {
       if (!empty($this->info[$type]['class'])) {
         $info = $this->info[$type];
         $class = $info['class'];
-        $this->types[$type] = new $class($type, $info['parameters']);
+        $this->types[$type] = new $class($type, $info + $info['parameters']);
       }
     }
     return $this->types[$type];

--- a/campaignion_action/src/TypeBase.php
+++ b/campaignion_action/src/TypeBase.php
@@ -3,6 +3,7 @@
 namespace Drupal\campaignion_action;
 
 abstract class TypeBase implements TypeInterface {
+
   /**
    * Content-type
    */
@@ -18,7 +19,9 @@ abstract class TypeBase implements TypeInterface {
   }
 
   public function defaultTemplateNid() {
-    return NULL;
+    $uuid = $this->parameters['template_node_uuid'];
+    $ids = \entity_get_id_by_uuid('node', [$uuid]);
+    return array_shift($ids);
   }
 
   public function actionFromNode($node) {
@@ -31,4 +34,5 @@ abstract class TypeBase implements TypeInterface {
   public function isDonation() {
     return FALSE;
   }
+
 }

--- a/campaignion_action/src/TypeBase.php
+++ b/campaignion_action/src/TypeBase.php
@@ -15,7 +15,9 @@ abstract class TypeBase implements TypeInterface {
 
   public function __construct($type, array $parameters = array()) {
     $this->type = $type;
-    $this->parameters = $parameters;
+    $this->parameters = $parameters + [
+      'action_class' => '\\Drupal\\campaignion_action\\ActionBase',
+    ];
   }
 
   public function defaultTemplateNid() {
@@ -24,8 +26,14 @@ abstract class TypeBase implements TypeInterface {
     return array_shift($ids);
   }
 
+  public function wizard($node = NULL) {
+    $class = $this->parameters['wizard_class'];
+    return new $class($this->parameters, $node, $this->type);
+  }
+
   public function actionFromNode($node) {
-    return new ActionBase($this, $node);
+    $class = $this->parameters['action_class'];
+    return new $class($this, $node);
   }
 
   /**

--- a/campaignion_action/src/TypeBase.php
+++ b/campaignion_action/src/TypeBase.php
@@ -17,6 +17,7 @@ abstract class TypeBase implements TypeInterface {
     $this->type = $type;
     $this->parameters = $parameters + [
       'action_class' => '\\Drupal\\campaignion_action\\ActionBase',
+      'donation' => FALSE,
     ];
   }
 
@@ -36,11 +37,12 @@ abstract class TypeBase implements TypeInterface {
     return new $class($this, $node);
   }
 
+
   /**
    * {@inheritdoc}
    */
   public function isDonation() {
-    return FALSE;
+    return $this->parameters['donation'];
   }
 
 }

--- a/campaignion_action/src/TypeBase.php
+++ b/campaignion_action/src/TypeBase.php
@@ -11,7 +11,7 @@ class TypeBase implements TypeInterface {
   /**
    * Parameters
    */
-  protected $parameters;
+  public $parameters;
 
   public function __construct($type, array $parameters = array()) {
     $this->type = $type;

--- a/campaignion_action/src/TypeBase.php
+++ b/campaignion_action/src/TypeBase.php
@@ -27,17 +27,6 @@ abstract class TypeBase implements TypeInterface {
     return array_shift($ids);
   }
 
-  public function wizard($node = NULL) {
-    $class = $this->parameters['wizard_class'];
-    return new $class($this->parameters, $node, $this->type);
-  }
-
-  public function actionFromNode($node) {
-    $class = $this->parameters['action_class'];
-    return new $class($this, $node);
-  }
-
-
   /**
    * {@inheritdoc}
    */

--- a/campaignion_action/src/TypeBase.php
+++ b/campaignion_action/src/TypeBase.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\campaignion_action;
 
-abstract class TypeBase implements TypeInterface {
+class TypeBase implements TypeInterface {
 
   /**
    * Content-type

--- a/campaignion_action/src/TypeInterface.php
+++ b/campaignion_action/src/TypeInterface.php
@@ -6,15 +6,7 @@ namespace Drupal\campaignion_action;
  * Every ActionType (Petition) has to implement this interface.
  */
 interface TypeInterface {
-  /**
-   * Return a wizard object for this ActionType.
-   *
-   * @param object $node The node to edit. Create a new one if NULL.
-   *
-   * @return \Drupal\oowizard\Wizard
-   *  The wizard responsible for changing/adding actions of this type.
-   */
-  public function wizard($node = NULL);
+
   /**
    * Check whether or not this action-type is a donation.
    *
@@ -22,4 +14,5 @@ interface TypeInterface {
    *   TRUE if this action type should be considered a donation else FALSE.
    */
   public function isDonation();
+
 }

--- a/campaignion_wizard/campaignion_wizard.module
+++ b/campaignion_wizard/campaignion_wizard.module
@@ -89,8 +89,8 @@ function campaignion_wizard_redirect($path) {
  */
 function campaignion_wizard_new($type) {
   $type = str_replace('-', '_', $type);
-  if ($action_type = Loader::instance()->type($type)) {
-    return $action_type->wizard()->run('content');
+  if ($wizard = Loader::instance()->wizard($type)) {
+    return $wizard->run('content');
   }
   return drupal_not_found();
 }
@@ -99,8 +99,8 @@ function campaignion_wizard_new($type) {
  * Page callback for wizard/%node/%step.
  */
 function campaignion_wizard($node = NULL, $step = 'content') {
-  if ($action_type = Loader::instance()->type($node->type)) {
-    return $action_type->wizard($node)->run($step);
+  if ($wizard = Loader::instance()->wizard($node->type, $node)) {
+    return $wizard->run($step);
   }
   else {
     require_once drupal_get_path('module', 'node') . '/node.pages.inc';


### PR DESCRIPTION
The main aim was to make dependency injection easier and thus make Actions more unit testable. All changes should be backwards compatible.

Here is a summary of the changes:

- Use a static constructor for actions: `ActionBase::fromTypeAndNode` instead of directly calling the constructor (and initializing members there).
- Make the Loader responsible for instantiating Wizard and Action classes.
- Use parameters to make all current `TypeBase` sub-classes obsolete.