### PR TITLE
[campaignion_google_analytics] Fix: check for 'ga'

### DIFF
--- a/campaignion_google_analytics/thank_you_page.js
+++ b/campaignion_google_analytics/thank_you_page.js
@@ -1,6 +1,8 @@
 (function($) {
     Drupal.behaviors.campaignion_google_analytics = {};
     Drupal.behaviors.campaignion_google_analytics.attach = function(context, settings) {
+        if (typeof ga === "undefined") { return; }
+
         var config =  settings.campaignion_google_analytics;
         if (typeof config === "undefined") {
           return


### PR DESCRIPTION
Check if 'ga' exists on thank you pages, too. Prevents js error on thank you pages when users are logged in and therefore Google Analytics is deactivated.