### PR TITLE
[cleverreach] Only set registered date for new subscriptions.

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters_cleverreach/src/CleverReach.php
+++ b/campaignion_newsletters/campaignion_newsletters_cleverreach/src/CleverReach.php
@@ -134,13 +134,13 @@ class CleverReach extends ProviderBase {
     $user = array(
       'email'  => $mail,
       'attributes' => $item->data,
-      'registered' => $item->created,
       'active' => !$opt_in,
       'activated' => $opt_in ? FALSE : $item->created,
     );
     $group_id = $list->data->id;
     $result = $this->api->receiverGetByEmail($group_id, $mail, 0);
     if ($result->message === 'data not found') {
+      $user['registered'] = $item->created;
       $result = $this->api->receiverAdd($group_id, $user);
     }
     else {

--- a/campaignion_newsletters/campaignion_newsletters_cleverreach/src/CleverReach.php
+++ b/campaignion_newsletters/campaignion_newsletters_cleverreach/src/CleverReach.php
@@ -19,12 +19,26 @@ use \Drupal\campaignion_newsletters\Subscription;
 class CleverReach extends ProviderBase {
   protected $account;
   protected $api;
+
   /**
-   * Constructor. Gets settings and fetches intial group list.
+   * Construct a new instance from config parameters.
    */
-  public function __construct(array $params) {
-    $this->account = $params['name'];
-    $this->api = new ApiClient($params['key']);
+  public static function fromParameters(array $params) {
+    $api = new ApiClient($params['key']);
+    return new static($api, $params['name']);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\campaignion_newsletters_cleverreach\ApiClient $api
+   *   Instance of our SoapClient sub-class.
+   * @param string $name
+   *   Name of this CleverReach account.
+   */
+  public function __construct(ApiClient $api, $name) {
+    $this->account = $name;
+    $this->api = $api;
   }
 
   /**

--- a/campaignion_newsletters/campaignion_newsletters_cleverreach/tests/CleverReachTest.php
+++ b/campaignion_newsletters/campaignion_newsletters_cleverreach/tests/CleverReachTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\campaignion_newsletters_cleverreach;
+
+use \Drupal\campaignion_newsletters\NewsletterList;
+use \Drupal\campaignion_newsletters\QueueItem;
+
+/**
+ * Test the CleverReach API implementation.
+ */
+class CleverReachTest extends \DrupalUnitTestCase {
+
+  /**
+   * Test that subscribe() does not pass 'registered' when updating subscribers.
+   */
+  public function testSubscribeUpdateNoRegisteredDate() {
+    $api = $this->getMockBuilder(ApiClient::class)
+      ->setMethods([
+        'receiverGetByEmail',
+        'receiverAdd',
+        'receiverUpdate',
+        'formsSendActivationMail',
+      ])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $cr = new CleverReach($api, 'test');
+
+    $result = (object) [
+      'status' => 'SUCCESS',
+      'data' => [],
+    ];
+    $item = new QueueItem(['created' => 42]);
+    $list = new NewsletterList(['data' => (object) ['id' => 42]]);
+    $api->expects($this->once())->method('receiverUpdate')
+      ->with($this->anything(), $this->equalTo([
+        'email' => $item->email,
+        'attributes' => NULL,
+        'active' => TRUE,
+        'activated' => 42,
+      ]))->willReturn($result);
+    $api->method('receiverGetByEmail')
+      ->willReturn((object) ['message' => 'found']);
+    $cr->subscribe($list, $item);
+  }
+
+}


### PR DESCRIPTION
Stop campaignion from overriding the registered date of existing subscribers.