### PR TITLE
[campaignion_webform_tokens] deduplicate tokens, add a hash token

### DIFF
--- a/campaignion_test/campaignion_test.info
+++ b/campaignion_test/campaignion_test.info
@@ -9,6 +9,7 @@ dependencies[] = campaignion_activity
 dependencies[] = campaignion_newsletters
 dependencies[] = campaignion_supporter_tags
 dependencies[] = campaignion_email_to_target
+dependencies[] = campaignion_webform_tokens
 dependencies[] = date
 dependencies[] = entity
 dependencies[] = features

--- a/campaignion_webform_tokens/campaignion_webform_tokens.module
+++ b/campaignion_webform_tokens/campaignion_webform_tokens.module
@@ -168,7 +168,7 @@ function _campaignion_webform_tokens_values($node, $submission) {
   $values = array();
   foreach ($components as $cid => $component) {
     $values[$component['form_key']] = NULL;
-    if ($v = $s->valuesByCid($cid)) {
+    if (($v = $s->valuesByCid($cid)) && (count($v) > 1 || reset($v))) {
       $values[$component['form_key']] = campaignion_webform_tokens_render_component($component, $v);
     }
   }

--- a/campaignion_webform_tokens/campaignion_webform_tokens.module
+++ b/campaignion_webform_tokens/campaignion_webform_tokens.module
@@ -29,6 +29,11 @@ function campaignion_webform_tokens_token_info() {
     'dynamic' => TRUE,
   ];
 
+  $submission['token-hash'] = [
+    'name' => t('Hashed sid'),
+    'description' => t('The hashed session id.'),
+  ];
+
   return array(
     'types' => $types,
     'tokens' => array(
@@ -67,8 +72,12 @@ function campaignion_webform_tokens_redirect($form, &$form_state) {
   $form_state['redirect'][1] += array('query' => array());
   $form_state['redirect'][1]['query'] += array(
     'sid' => $sid,
-    'hash' => drupal_hmac_base64($sid, drupal_get_private_key() . drupal_get_hash_salt()),
+    'hash' => campaignion_webform_tokens_hash_sid($sid),
   );
+}
+
+function campaignion_webform_tokens_hash_sid($sid) {
+  return drupal_hmac_base64((int) $sid, drupal_get_private_key() . drupal_get_hash_salt());
 }
 
 /**
@@ -78,28 +87,28 @@ function campaignion_webform_tokens_tokens($type, $tokens, array $data = array()
   $replacements = array();
   if ($type != 'submission')
     return $replacements;
- 
+
   $sid = (isset($_GET['sid']) && is_numeric($_GET['sid'])) ? (int) $_GET['sid'] : 0;
   $hash = isset($_GET['hash']) ? $_GET['hash'] : NULL;
 
+  $submission = NULL;
   $values = [];
-  if ($submission = _campaignion_webform_tokens_get_submission($sid, $hash)) {
+  if (isset($data['webform-submission'])) {
+    $submission = $data['webform-submission'];
+  }
+  elseif ($submission = _campaignion_webform_tokens_get_submission($sid, $hash)) {
     $data['webform-submission'] = $submission;
     $data['node'] = node_load($submission->nid);
     if (function_exists('webform_tokens')) {
       $replacements += webform_tokens($type, $tokens, $data, $options);
     }
-    $values = _campaignion_webform_tokens_values($submission);
   }
-  else {
+  if (!$submission) {
     return $replacements;
   }
+  $values = _campaignion_webform_tokens_values($submission);
 
   foreach ($tokens as $name => $original) {
-    // Defer to webform4.
-    if (isset($replacements[$original])) {
-      continue;
-    }
     // Split token name to get the components name. The remainder is our default value.
     $token = explode('/', $name, 2);
     if (count($token) < 2) {
@@ -109,13 +118,22 @@ function campaignion_webform_tokens_tokens($type, $tokens, array $data = array()
     if (substr($token, 0, 9) == 'text-val:') {
       $token = substr($token, 9);
     }
-    if (isset($values[$token])) {
-      // render webform component.
-      $replacements[$original] = $values[$token];
-    } else {
-      $replacements[$original] = $default;
+    if (array_key_exists($token, $values)) {
+      if (isset($values[$token])) {
+        // render webform component.
+        $replacements[$original] = $values[$token];
+      }
+      else {
+        $replacements[$original] = $default;
+      }
     }
   }
+
+  // Make the hash available as a token.
+  if (isset($tokens['token-hash'])) {
+    $replacements[$tokens['token-hash']] = campaignion_webform_tokens_hash_sid($submission->sid);
+  }
+
   return $replacements;
 }
 
@@ -124,7 +142,7 @@ function _campaignion_webform_tokens_get_submission($sid, $hash) {
   //  - check if hash is present and valid
   //  - don't replace anything if hashes don't match.
   if (variable_get('campaignion_webform_tokens_use_hash', '1') == '1') {
-    if ($hash !=  drupal_hmac_base64((int) $sid, drupal_get_private_key() . drupal_get_hash_salt()))
+    if ($hash != campaignion_webform_tokens_hash_sid($sid))
       return FALSE;
   }
 
@@ -139,6 +157,7 @@ function _campaignion_webform_tokens_values($submission) {
   $components = $s->webform->node->webform['components'];
   $values = array();
   foreach ($components as $cid => $component) {
+    $values[$component['form_key']] = NULL;
     if ($v = $s->valuesByCid($cid)) {
       $values[$component['form_key']] = campaignion_webform_tokens_render_component($component, $v);
     }

--- a/campaignion_webform_tokens/campaignion_webform_tokens.module
+++ b/campaignion_webform_tokens/campaignion_webform_tokens.module
@@ -115,7 +115,8 @@ function campaignion_webform_tokens_tokens($type, $tokens, array $data = array()
   if (!$submission) {
     return $replacements;
   }
-  $values = _campaignion_webform_tokens_values($submission);
+  $node = !empty($data['node']) ? $data['node'] : node_load($submission->nid);
+  $values = _campaignion_webform_tokens_values($node, $submission);
 
   foreach ($tokens as $name => $original) {
     // Split token name to get the components name. The remainder is our default value.
@@ -161,8 +162,8 @@ function _campaignion_webform_tokens_get_submission($sid, $hash) {
   return isset($submission[$sid]) ? $submission[$sid] : FALSE;
 }
 
-function _campaignion_webform_tokens_values($submission) {
-  $s = new Submission(node_load($submission->nid), $submission);
+function _campaignion_webform_tokens_values($node, $submission) {
+  $s = new Submission($node, $submission);
   $components = $s->webform->node->webform['components'];
   $values = array();
   foreach ($components as $cid => $component) {

--- a/campaignion_webform_tokens/campaignion_webform_tokens.module
+++ b/campaignion_webform_tokens/campaignion_webform_tokens.module
@@ -76,6 +76,14 @@ function campaignion_webform_tokens_redirect($form, &$form_state) {
   );
 }
 
+/**
+ * Returns a safe HMAC value for a submission ID used for authentication.
+ *
+ * @param int $sid
+ *   The submission ID.
+ * @return string
+ *   The HMAC signature.
+ */
 function campaignion_webform_tokens_hash_sid($sid) {
   return drupal_hmac_base64((int) $sid, drupal_get_private_key() . drupal_get_hash_salt());
 }
@@ -85,8 +93,9 @@ function campaignion_webform_tokens_hash_sid($sid) {
  */
 function campaignion_webform_tokens_tokens($type, $tokens, array $data = array(), array $options = array()) {
   $replacements = array();
-  if ($type != 'submission')
+  if ($type != 'submission') {
     return $replacements;
+  }
 
   $sid = (isset($_GET['sid']) && is_numeric($_GET['sid'])) ? (int) $_GET['sid'] : 0;
   $hash = isset($_GET['hash']) ? $_GET['hash'] : NULL;

--- a/campaignion_webform_tokens/tests/TokensTest.php
+++ b/campaignion_webform_tokens/tests/TokensTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\campaignion_webform_tokens;
+
+module_load_include('inc', 'webform', 'includes/webform.components');
+module_load_include('inc', 'webform', 'includes/webform.submissions');
+
+class TokensTest extends \DrupalUnitTestCase {
+
+  protected function stubData() {
+    return [
+      'node' => (object) [
+        'nid' => 42,
+        'type' => 'webform',
+        'status' => 1,
+        'webform' => [
+          'components' => [
+            1 => [
+              'cid' => 1,
+              'type' => 'email',
+              'form_key' => 'email',
+              'page_num' => 1,
+            ] + webform_component_invoke('email', 'defaults'),
+            2 => [
+              'cid' => 2,
+              'type' => 'textfield',
+              'form_key' => 'name',
+              'page_num' => 1,
+            ] + webform_component_invoke('textfield', 'defaults'),
+          ],
+          'conditionals' => [],
+        ],
+      ],
+      'webform-submission' => (object) [
+        'sid' => 42,
+        'nid' => 42,
+        'completed' => TRUE,
+        'data' => [
+          1 => ['test@example.com'],
+        ],
+      ],
+    ];
+  }
+
+  public function testTokenEmailField() {
+    $data = $this->stubData();
+    // Replace webform4-style token.
+    $this->assertEqual('test@example.com', token_replace('[submission:values:email]', $data));
+    // Replace text-val token.
+    $this->assertEqual('test@example.com', token_replace('[submission:text-val:email]', $data));
+    // Default is not replaced if component doesn't exist.
+    $this->assertEqual('[submission:text-val:none/default]', token_replace('[submission:text-val:none/default]', $data));
+    // Default is replaced if there is no value.
+    $this->assertEqual('None', token_replace('[submission:text-val:name/None]', $data));
+  }
+
+  public function testHashToken() {
+    $data = $this->stubData();
+    $this->assertRegExp('/[a-zA-Z0-9\-_]{42}/', token_replace('[submission:token-hash]', $data));
+  }
+
+}
+


### PR DESCRIPTION
* Make the hash available as a token.
* Deduplicate tokens: don’t add the standard tokens that
  are added to $replacements by webform_tokens.