### PR TITLE
[optivo] Try to subscribe() on update().

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters_optivo/src/Optivo.php
+++ b/campaignion_newsletters/campaignion_newsletters_optivo/src/Optivo.php
@@ -120,11 +120,16 @@ class Optivo extends ProviderBase {
    * Update user data.
    */
   public function update(NewsletterList $list, QueueItem $item) {
-    $service = $this->factory->getClient('Recipient');
-    $data = $item->data + ['names' => [], 'values' => []];
-    $service->setAttributes($list->identifier, $item->email, $data['names'], $data['values']);
+    // The best way to do this would be to try a setAttributes() call and then
+    // if that fails because the recipient does not yet exist try to subscribe.
+    // However the exception thrown by setAttributes() does not easily provide
+    // the information why it failed.
+    // The only other option would be to call contains() first and then either
+    // subscribe() or setAttributes() which means just as many API-calls.
+    $item->args['send_optin'] = FALSE;
+    $item->args['send_welcome'] = FALSE;
+    $this->subscribe($list, $item);
   }
-
 
   /**
    * Unsubscribe a user, given a newsletter identifier and email address.

--- a/campaignion_newsletters/campaignion_newsletters_optivo/tests/OptivoTest.php
+++ b/campaignion_newsletters/campaignion_newsletters_optivo/tests/OptivoTest.php
@@ -4,6 +4,7 @@ namespace Drupal\campaignion_newsletters_optivo;
 
 use \Drupal\campaignion\CRM\Import\Source\ArraySource;
 use \Drupal\campaignion_newsletters\NewsletterList;
+use \Drupal\campaignion_newsletters\QueueItem;
 use \Drupal\campaignion_newsletters\Subscription;
 
 /**
@@ -14,14 +15,15 @@ class OptivoTest extends \DrupalUnitTestCase {
   /**
    * Construct a partially stubbed Optivo object using a mock Client object.
    */
-  protected function mockProvider() {
+  protected function mockProvider($overrides = []) {
+    $overrides[] = 'getSource';
     $api = $this->getMockBuilder(Client::class)
       ->setMethods([
       ])
       ->disableOriginalConstructor()
       ->getMock();
     $cr = $this->getMockBuilder(Optivo::class)
-      ->setMethods(['getSource'])
+      ->setMethods($overrides)
       ->disableOriginalConstructor()
       ->getMock();
     return [$cr, $api];
@@ -85,6 +87,22 @@ class OptivoTest extends \DrupalUnitTestCase {
       'names' => ['Firstname', 'Lastname'],
       'values' => ['test', 'test'],
     ], $data);
+  }
+
+  /**
+   * Test that the update function simply calls subscribe().
+   */
+  public function testUpdateCallsSubscribe() {
+    list($cr, $api) = $this->mockProvider(['subscribe']);
+    $l = new NewsletterList(['list_id' => 'list-id']);
+    $q = new QueueItem([
+      'list_id' => 'list-id',
+      'email' => 'test@example.com',
+      'data' => ['names' => [], 'values' => []],
+    ]);
+    $cr->expects($this->once())->method('subscribe')
+      ->with($this->equalTo($l), $this->equalTo($q));
+    $cr->update($l, $q);
   }
 
 }


### PR DESCRIPTION
Optivo throws a SoapFault error if we try to setAttributes() on a non-existing subscriber. Yes, mismatches between campaiginon's and Optivo's subscriber list can and will happen.

Easiest solution: Use the same function for both, but ensure no optin-email is triggered for updates.