### PR TITLE
Fix z2010: Duplicate contacts. Orphaned activities. Notices.

### DIFF
--- a/campaignion.info
+++ b/campaignion.info
@@ -1,7 +1,7 @@
 name = Campaignion
 description = Base module for all campaignion features.
 core = 7.x
-php = 5.4
+php = 5.5
 package = Campaignion
 project = campaignion
 

--- a/campaignion.install
+++ b/campaignion.install
@@ -5,6 +5,37 @@ function campaignion_uninstall() {
 }
 
 /**
+ * Delete duplicate contacts.
+ */
+function campaignion_update_8() {
+  $sql = <<<SQL
+SELECT f1.entity_id AS did, f2.entity_id AS oid
+FROM {field_data_redhen_contact_email} f1
+  INNER JOIN {field_data_redhen_contact_email} f2 ON f1.entity_id > f2.entity_id AND f1.bundle = f2.bundle AND f1.redhen_contact_email_value=f2.redhen_contact_email_value
+  LEFT OUTER JOIN {field_data_redhen_contact_email} f3 ON f2.entity_id > f3.entity_id AND f2.bundle=f3.bundle AND f3.redhen_contact_email_value=f2.redhen_contact_email_value
+WHERE f3.entity_id IS NULL
+SQL;
+
+  $i = 0;
+  foreach (db_query($sql) as $row) {
+    if (module_exists('campaignion_activity')) {
+      // Remap all activities to the "original" contact.
+      db_query("UPDATE {campaignion_activity} SET contact_id={$row->oid} WHERE contact_id={$row->did}");
+    }
+    if (module_exists('campaignion_newsletters')) {
+      // Avoid deleting subscriptions by feeding an empty Subscriptions object
+      // into campaignion_newsletters_entity_delete().
+      $contact = entity_load_single('redhen_contact', $row->did);
+      $contact->newsletters = new \Drupal\campaignion_newsletters\Subscriptions([], [], []);
+    }
+    entity_delete('redhen_contact', $row->did);
+    $i++;
+  }
+
+  return t("!count duplicate contacts have been deleted.", ['!count' => $i]);
+}
+
+/**
  * Increase weight above i18n. -> switch_links_alter()
  */
 function campaignion_update_7() {

--- a/campaignion_activity/campaignion_activity.install
+++ b/campaignion_activity/campaignion_activity.install
@@ -151,6 +151,21 @@ function campaignion_activity_uninstall() {
 }
 
 /**
+ * Delete orphaned activities.
+ */
+function campaignion_activity_update_3() {
+  $sql = <<<SQL
+DELETE ca, caw, cap
+FROM {campaignion_activity} ca
+  LEFT OUTER JOIN {campaignion_activity_webform} caw USING(activity_id)
+  LEFT OUTER JOIN {campaignion_activity_payment} cap USING(activity_id)
+  LEFT OUTER JOIN {redhen_contact} c USING(contact_id)
+WHERE c.contact_id IS NULL
+SQL;
+  db_query($sql);
+}
+
+/**
  * Fixup unconfirmed webform actvities.
  */
 function campaignion_activity_update_2() {

--- a/campaignion_activity/campaignion_activity.module
+++ b/campaignion_activity/campaignion_activity.module
@@ -60,3 +60,19 @@ function campaignion_activity_entity_update($entity, $entity_type) {
     $activity->save();
   }
 }
+
+/**
+ * Implements hook_entity_delete().
+ */
+function campaignion_activity_entity_delete($entity, $entity_type) {
+  if ($entity_type == 'redhen_contact') {
+    $sql = <<<SQL
+DELETE ca, caw, cap
+FROM {campaignion_activity} ca
+  LEFT OUTER JOIN {campaignion_activity_webform} caw USING(activity_id)
+  LEFT OUTER JOIN {campaignion_activity_payment} cap USING(activity_id)
+WHERE ca.contact_id=:contact_id
+SQL;
+    db_query($sql, [':contact_id' => $entity->contact_id]);
+  }
+}

--- a/campaignion_newsletters/src/Subscriptions.php
+++ b/campaignion_newsletters/src/Subscriptions.php
@@ -65,7 +65,9 @@ class Subscriptions {
   public function unsubscribeAll() {
     foreach ($this->subscriptions as $email => $lists) {
       foreach ($lists as $list_id => $subscription) {
-        $subscription->delete = TRUE;
+        if ($subscription) {
+          $subscription->delete = TRUE;
+        }
       }
     }
   }

--- a/src/CRM/ImporterBase.php
+++ b/src/CRM/ImporterBase.php
@@ -23,7 +23,33 @@ class ImporterBase {
     return $isNewOrUpdated;
   }
 
+  /**
+   * Create or find a contact using a source.
+   *
+   * @param \Drupal\campaignion\CRM\Import\Source\SourceInterface $source
+   *   A contact data source.
+   *
+   * @return \Drupal\campaignion\Contact
+   *   A new or existing contact matching this source.
+   */
   public function findOrCreateContact(SourceInterface $source) {
-    return Contact::fromEmail($source->value('email'), $this->contactType);
+    $email = $source->value('email');
+    $lock = "campaignion_findOrCreateContact:{$this->contactType}:$email";
+    try {
+      // Use a lock to avoid multiple threads creating the same contact.
+      while (!lock_acquire($lock, 5)) {
+        lock_wait($lock, 30);
+      }
+      $contact = Contact::fromEmail($source->value('email'), $this->contactType);
+      if (!$contact->contact_id) {
+        // Create contact immediately, so that successive calls to this function
+        // will return the same contact.
+        $contact->save();
+      }
+      return $contact;
+    }
+    finally {
+      lock_release($lock);
+    }
   }
 }

--- a/src/Contact.php
+++ b/src/Contact.php
@@ -36,7 +36,8 @@ class Contact extends \RedhenContact {
     $sql = <<<SQL
 SELECT entity_id
 FROM field_data_redhen_contact_email
-WHERE redhen_contact_email_value = :email AND bundle = :bundle
+  INNER JOIN redhen_contact ON entity_id=contact_id
+WHERE redhen_contact_email_value = :email AND type = :bundle AND redhen_state = 1
 SQL;
     return db_query($sql, array(':email' => $email, ':bundle' => $type))->fetchField();
   }


### PR DESCRIPTION
This is a stab at removing multiple issues associated with duplicate contacts.

* Locking for ImporterBase::findOrCreateContact().
* Migration to remove duplicate contacts.
* Delete activities when deleting a contact.
* Migration to delete orphaned activities.
* Don't try to delete non-existing Subscriptions in `hook_entity_delete()`
* Only get actually existing contacts in `Contact::idByEmail()`. Normally this shouldn't be needed for a consistent database. It was needed for a database where contacts where deleted in the `redhen_contact` table directly without deleting any of the fields. It doesn't hurt either.