### PR TITLE
[newsletters] Store non-checked values more like actual select component.

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -201,12 +201,8 @@ function _webform_submit_newsletter($component, $value) {
  * Implements _webform_display_component().
  */
 function _webform_display_newsletter($component, $value, $format = 'html') {
-  if (!empty($value['subscribed'])) {
-    return array('#markup' => t('subscribed'));
-  }
-  else {
-    return array('#markup' => t('not subscribed'));
-  }
+  $v['#markup'] = !empty($value[0]) ? t('subscribed') : t('not subscribed');
+  return $v;
 }
 
 /**
@@ -314,8 +310,7 @@ function _webform_form_builder_map_newsletter() {
  * Implements _webform_table_component().
  */
 function _webform_table_newsletter($component, $value) {
-  $v = empty($value['subscribed']) ? t('not subscribed') : t('subscribed');
-  return $v;
+  return empty($value[0]) ? t('not subscribed') : t('subscribed');
 }
 
 /**
@@ -333,12 +328,5 @@ function _webform_csv_headers_newsletter($component, $export_options) {
  * Implements _webform_csv_data_component().
  */
 function _webform_csv_data_newsletter($component, $export_options, $value) {
-  $v = t('not subscribed');
-  # value of field 'subscribed' set to 'subscribed' if checkbox checked,
-  # '0' otherwise
-  if (!empty($value['subscribed'])) {
-    $v = t('subscribed');
-  }
-  return $v;
+  return empty($value[0]) ? t('not subscribed') : t('subscribed');
 }
-

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -176,7 +176,6 @@ function _webform_render_newsletter($component, $value = NULL, $filter = TRUE) {
         '#type' => 'radios',
         '#default_value' => !empty($component['value']['subscribed']) ? 'yes' : NULL,
         '#options' => $options,
-        '#element_validate' => ['_campaignion_newsletters_radio_values'],
       ];
   }
 
@@ -184,13 +183,18 @@ function _webform_render_newsletter($component, $value = NULL, $filter = TRUE) {
 }
 
 /**
- * Element validate handler for newsletter opt-in as radios.
- *
- * Transform value into whatever the checkbox would evaluate to.
+ * Implements _webform_submit_COMPONENT().
  */
-function _campaignion_newsletters_radio_values($element, &$form_state) {
-  $value = &drupal_array_get_nested_value($form_state['values'], $element['#parents']);
-  $value = ['subscribed' => $value == 'yes' ? 'subscribed' : 0];
+function _webform_submit_newsletter($component, $value) {
+  switch ($component['extra']['display']) {
+    case 'checkbox':
+      return empty($value['subscribed']) ? [''] : ['subscribed'];
+      break;
+
+    case 'radios':
+      return $value == 'yes' ? ['subscribed'] : [''];
+      break;
+  }
 }
 
 /**

--- a/campaignion_newsletters/campaignion_newsletters.install
+++ b/campaignion_newsletters/campaignion_newsletters.install
@@ -180,7 +180,7 @@ function campaignion_newsletters_update_13() {
 UPDATE
   d {webform_submitted_data} d
   INNER JOIN {webform_component} c
-SET d.data=''
+SET d.data='', d.no='0'
 WHERE c.type='newsletter' AND d.data='0';
 SQL;
   db_query($sql);

--- a/campaignion_newsletters/campaignion_newsletters.install
+++ b/campaignion_newsletters/campaignion_newsletters.install
@@ -173,6 +173,20 @@ function campaignion_newsletters_uninstall() {
 }
 
 /**
+ * Replace '0' entries for not-subscribed submissions with ''.
+ */
+function campaignion_newsletters_update_13() {
+  $sql = <<<SQL
+UPDATE
+  d {webform_submitted_data} d
+  INNER JOIN {webform_component} c
+SET d.data=''
+WHERE c.type='newsletter' AND d.data='0';
+SQL;
+  db_query($sql);
+}
+
+/**
  * Make campaignion_newsletters_queue.action a string column + custom args.
  */
 function campaignion_newsletters_update_12() {

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -95,8 +95,7 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
     return;
   }
   foreach ($s->webform->componentsByType('newsletter') as $component) {
-    $value = $s->valuesByCid($component['cid']);
-    if (!empty($value['subscribed'])) {
+    if ($s->valueByCid($component['cid'])) {
       $needs_opt_in = !$component['extra']['opt_in_implied'];
       foreach ($component['extra']['lists'] as $list_id => $value) {
         if (!empty($value)) {

--- a/campaignion_newsletters/tests/ComponentTest.php
+++ b/campaignion_newsletters/tests/ComponentTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\campaignion_newsletters;
+
+class ComponentTest extends \DrupalUnitTestCase {
+
+  public function setUp() {
+    require_once drupal_get_path('module', 'campaignion_newsletters') . '/campaignion_newsletters.component.inc';
+  }
+
+  public function testSubmitCheckbox() {
+    $c['extra']['display'] = 'checkbox';
+
+    // Not checked checkbox.
+    $v['subscribed'] = 0;
+    $this->assertEqual([''], _webform_submit_newsletter($c, $v));
+
+    // Checked checkbox.
+    $v['subscribed'] = 'subscribed';
+    $this->assertEqual(['subscribed'], _webform_submit_newsletter($c, $v));
+  }
+
+  public function testSubmitRadios() {
+    $c['extra']['display'] = 'radios';
+
+    // Not checked checkbox.
+    $v = 'no';
+    $this->assertEqual([''], _webform_submit_newsletter($c, $v));
+
+    // Checked checkbox.
+    $v = 'yes';
+    $this->assertEqual(['subscribed'], _webform_submit_newsletter($c, $v));
+  }
+
+}


### PR DESCRIPTION
Currently not selected values for the newsletter component are stored as string `'0'`. The webform select component uses an empty string `''` to represent the not-checked state.

This makes it easier for other modules to check whether an opt-in was made as a single `!empty($value[0])` is enough.