### PR TITLE
Fix mailchimp notices

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/src/MailChimp.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/src/MailChimp.php
@@ -146,7 +146,7 @@ class MailChimp extends ProviderBase {
       if (isset($webhook_urls[$webhook_url])) {
         unset($webhook_urls[$webhook_url]);
       }
-      elseif($register) {
+      elseif ($register) {
         $this->api->post("/lists/{$list->identifier}/webhooks", [], [
           'url' => $webhook_url,
           'events' => [

--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/src/MailChimp.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/src/MailChimp.php
@@ -212,6 +212,7 @@ class MailChimp extends ProviderBase {
    */
   public function data(Subscription $subscription) {
     $data['merge_fields'] = $this->attributeData($subscription);
+    $data['interests'] = [];
     // Let other modules alter the data (ie. for adding interest groups).
     drupal_alter('campaignion_newsletters_mailchimp_data', $data, $subscription);
     $fingerprint = sha1(serialize($data));

--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/src/MailChimp.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/src/MailChimp.php
@@ -19,6 +19,7 @@ class MailChimp extends ProviderBase {
 
   protected $account;
   protected $api;
+  protected $registerWebhooks;
 
   /**
    * Extract the DC from a valid API-key.
@@ -40,15 +41,17 @@ class MailChimp extends ProviderBase {
   public static function fromParameters(array $params) {
     $dc = static::key2dc($params['key']);
     $endpoint = "https://campaignion:{$params['key']}@{$dc}.api.mailchimp.com/3.0";
-    return new static(new MailChimpClient($endpoint), $params['name']);
+    $webhooks = variable_get('campaignion_newsletters_mailchimp_register_webhooks', TRUE) && variable_get('webhooks_enabled', TRUE);
+    return new static(new MailChimpClient($endpoint), $params['name'], $webhooks);
   }
 
   /**
    * Constructor. Gets settings and fetches intial group list.
    */
-  public function __construct($api, $name) {
+  public function __construct($api, $name, $register_webhooks) {
     $this->api = $api;
     $this->account = $name;
+    $this->registerWebhooks = $register_webhooks;
   }
 
   /**
@@ -111,7 +114,7 @@ class MailChimp extends ProviderBase {
    * Staging and development installations should set one of these to FALSE.
    */
   protected function registerWebhooks() {
-    return variable_get('campaignion_newsletters_mailchimp_register_webhooks', TRUE) && variable_get('webhooks_enabled', TRUE);
+    return $this->registerWebhooks;
   }
 
   /**

--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/tests/MailChimpTest.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/tests/MailChimpTest.php
@@ -38,7 +38,7 @@ class MailChimpTest extends \DrupalUnitTestCase {
       ->setMethods($methods)
       ->disableOriginalConstructor()
       ->getMock();
-    return [$api, new MailChimp($api, 'testname')];
+    return [$api, new MailChimp($api, 'testname', TRUE)];
   }
 
   /**

--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/tests/MailChimpTest.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/tests/MailChimpTest.php
@@ -2,8 +2,10 @@
 
 namespace Drupal\campaignion_newsletters_mailchimp;
 
+use \Drupal\campaignion\CRM\Import\Source\ArraySource;
 use \Drupal\campaignion_newsletters\NewsletterList;
 use \Drupal\campaignion_newsletters\QueueItem;
+use \Drupal\campaignion_newsletters\Subscription;
 use \Drupal\little_helpers\Rest\HttpError;
 
 use \Drupal\campaignion_newsletters_mailchimp\Rest\ApiError;
@@ -38,7 +40,38 @@ class MailChimpTest extends \DrupalUnitTestCase {
       ->setMethods($methods)
       ->disableOriginalConstructor()
       ->getMock();
-    return [$api, new MailChimp($api, 'testname', TRUE)];
+    $provider = $this->getMockBuilder(MailChimp::class)
+      ->setMethods(['getSource'])
+      ->setConstructorArgs([$api, 'testname', TRUE])
+      ->getMock();
+    return [$api, $provider];
+  }
+
+  /**
+   * Generate a mock subscription with an accompanying list.
+   *
+   * @param string $email
+   *   An email address.
+   * @param string[] $merge_tags
+   *   A list of uppercase MailChimp merge tags.
+   *
+   * @return \Drupal\campaignion_newsletters\Subscription
+   *   A newly created subscription object.
+   */
+  protected function mockSubscription($email, array $merge_tags) {
+    $merge_vars = array_map(function ($tag) {
+      return ['tag' => $tag];
+    }, $merge_tags);
+    $subscription = $this->getMockBuilder(Subscription::class)
+      ->setMethods(['newsletterList'])
+      ->setConstructorArgs([['email' => $email], TRUE])
+      ->getMock();
+    $subscription->expects($this->any())->method('newsletterList')
+      ->will($this->returnValue(new NewsletterList([
+        'list_id' => 2048,
+        'data' => (object) ['merge_vars' => $merge_vars],
+      ])));
+    return $subscription;
   }
 
   /**
@@ -100,10 +133,21 @@ class MailChimpTest extends \DrupalUnitTestCase {
     ]);
     list($api, $provider) = $this->mockChimp(['put']);
     $item = new QueueItem([
+      'email' => 'test@example.com',
       'args' => ['send_optin' => FALSE],
-      'data' => ['FNAME' => 'Test', 'LNAME' => 'Test', 'merge_fields' => []],
+      'data' => [
+        'merge_fields' => ['FNAME' => 'Test', 'LNAME' => 'Test'],
+        'interests' => [],
+      ],
     ]);
-    $api->expects($this->once())->method('put');
+    $post_data = [
+      'email_address' => 'test@example.com',
+      'status' => 'subscribed',
+      'merge_fields' => (object) ['FNAME' => 'Test', 'LNAME' => 'Test'],
+      'interests' => (object) [],
+    ];
+    $api->expects($this->once())->method('put')
+      ->with($this->anything(), $this->anything(), $post_data, $this->anything());
     $provider->subscribe($list_o, $item);
   }
 
@@ -194,6 +238,36 @@ class MailChimpTest extends \DrupalUnitTestCase {
     );
 
     $provider->setWebhooks([$list_o]);
+  }
+
+  /**
+   * Test format of the data array.
+   */
+  public function testDataEmpty() {
+    list($api, $provider) = $this->mockChimp();
+    $provider->expects($this->any())->method('getSource')
+      ->will($this->returnValue(new ArraySource([])));
+    $subscription = $this->mockSubscription('test@example.com', []);
+    list($data, $fingerprint) = $provider->data($subscription);
+    $this->assertEqual(['merge_fields' => [], 'interests' => []], $data);
+  }
+
+  /**
+   * Test data with merge tags.
+   */
+  public function testDataWithTags() {
+    list($api, $provider) = $this->mockChimp();
+    $provider->expects($this->any())->method('getSource')
+      ->will($this->returnValue(new ArraySource([
+        'FNAME' => 'Fname',
+        'OTHER' => 'Other',
+      ])));
+    $subscription = $this->mockSubscription('test@example.com', ['FNAME']);
+    list($data, $fingerprint) = $provider->data($subscription);
+    $this->assertEqual([
+      'merge_fields' => ['FNAME' => 'Fname'],
+      'interests' => [],
+    ], $data);
   }
 
 }


### PR DESCRIPTION
* Always have interests and merge_fields at least as empty array.
* Explicitly cast interests and merge_fields as objects before `json_encode()`. Otherwise empty arrays are rendered as lists instead of as empty objects.