### PR TITLE
[e2t] Use check_plain() instead of using token_replace() sanitize.

### DIFF
--- a/campaignion_email_to_target/src/Component.php
+++ b/campaignion_email_to_target/src/Component.php
@@ -133,7 +133,7 @@ class Component {
         $no_target_message = t("There don't seem to be any targets for your selection.");
       }
       $element['no_target'] = [
-        '#markup' => _filter_autop($no_target_message),
+        '#markup' => _filter_autop(check_plain($no_target_message)),
       ];
       $element['#attributes']['class'][] = 'email-to-target-no-targets';
       $this->disableSubmits($form);
@@ -162,7 +162,7 @@ class Component {
       ];
       $t['header'] = [
         '#prefix' => '<pre class="email-to-target-header">',
-        '#markup' => $message->header,
+        '#markup' => check_plain($message->header),
         '#suffix' => '</pre>',
       ];
       $t['message'] = [
@@ -173,7 +173,7 @@ class Component {
       ];
       $t['footer'] = [
         '#prefix' => '<pre class="email-to-target-footer">',
-        '#markup' => $message->footer,
+        '#markup' => check_plain($message->footer),
         '#suffix' => '</pre>',
       ];
       $element[$target['id']] = $t;

--- a/campaignion_email_to_target/src/Component.php
+++ b/campaignion_email_to_target/src/Component.php
@@ -11,27 +11,26 @@ use \Drupal\campaignion_email_to_target\Api\Client;
  * Implement behavior for the email to target message webform component.
  */
 class Component {
-  protected $component;
-  protected $payment = NULL;
 
-  public function __construct(array $component) {
-    $this->component = $component;
-  }
+  protected $component;
+  protected $webform;
+  protected $action;
+  protected $options;
 
   /**
-   * Get a list of parent form keys for this component.
-   *
-   * @return array
-   *   List of parent form keys - just like $element['#parents'].
+   * Static constructor to inject dependencies based on a component array.
    */
-  public function parents($webform) {
-    $parents = array($this->component['form_key']);
-    $parent = $this->component;
-    while ($parent['pid'] != 0) {
-      $parent = $webform->component($parent['pid']);
-      array_unshift($parents, $parent['form_key']);
-    }
-    return $parents;
+  public static function fromComponent(array $component) {
+    $node = node_load($this->component['nid']);
+    $webform = new Webform($node);
+    $action = Loader::instance()->actionFromNode($node);
+    return new static($component, $webform, $action);
+  }
+
+  public function __construct(array $component, Webform $webform, Action $action) {
+    $this->component = $component;
+    $this->webform = $webform;
+    $this->action = $action;
   }
 
   /**
@@ -46,13 +45,9 @@ class Component {
    */
   public function render(&$element, &$form, &$form_state) {
     // Get list of targets for this node.
-    $node = node_load($this->component['nid']);
-    $webform = new Webform($node);
-    $action = Loader::instance()->actionFromNode($node);
-    $options = $action->getOptions();
-    $submission_o = $webform->formStateToSubmission($form_state);
+    $submission_o = $this->webform->formStateToSubmission($form_state);
+    $options = $this->action->getOptions();
 
-    $postcode = str_replace(' ', '', $submission_o->valueByKey('postcode'));
     $test_mode = !empty($form_state['test_mode']);
     $email = $submission_o->valueByKey('email');
 
@@ -80,8 +75,7 @@ class Component {
     $element['#attributes']['class'][] = 'webform-prefill-exclude';
 
     try {
-      $api = Client::fromConfig();
-      $constituencies = $api->getTargets($options['dataset_name'], $postcode);
+      list($pairs, $no_target_message) = $this->action->targetMessagePairs($submission_o, $test_mode);
     }
     catch (\Exception $e) {
       watchdog_exception('campaignion_email_to_target', $e);
@@ -94,44 +88,7 @@ class Component {
       return;
     }
 
-    $pairs = [];
-    $no_target_message = NULL;
-    foreach ($constituencies as $constituency) {
-      if ($exclusion = $action->getExclusion($constituency)) {
-        $exclusion->replaceTokens([], $constituency, $submission_o->unwrap());
-        if (!$no_target_message) {
-          $no_target_message = $exclusion->message;
-        }
-        continue;
-      }
-      $targets = $constituency['contacts'];
-      foreach ($targets as $target) {
-        if ($message = $action->getMessage($target, $constituency)) {
-          if ($test_mode) {
-            $target['email'] = $email;
-          }
-          $message->replaceTokens($target, $constituency, $submission_o->unwrap());
-          if ($message->type == 'exclusion') {
-            // The first exclusion-message is used.
-            if (!$no_target_message) {
-              $no_target_message = $message->message;
-            }
-          }
-          else {
-            $pairs[] = [$target, $message];
-          }
-        }
-      }
-    }
-
     if (empty($pairs)) {
-      watchdog('campaignion_email_to_target', 'The API found no targets (dataset=@dataset, postcode=@postcode).', [
-        '@dataset' => $options['dataset_name'],
-        '@postcode' => $postcode,
-      ], WATCHDOG_WARNING);
-      if (!$no_target_message) {
-        $no_target_message = t("There don't seem to be any targets for your selection.");
-      }
       $element['no_target'] = [
         '#markup' => _filter_autop(check_plain($no_target_message)),
       ];

--- a/campaignion_email_to_target/src/Message.php
+++ b/campaignion_email_to_target/src/Message.php
@@ -38,8 +38,12 @@ class Message {
     $data['email-to-target'] = $target;
     $data['email-to-target-constituency'] = $constituency;
     $data['webform-submission'] = $submission;
+    // It's ok to not sanitize values here. We will sanitize them later
+    // when it's clear whether we use it in a plain text email (no escaping)
+    // or in HTML output (check_plain).
+    $options['sanitize'] = FALSE;
     foreach ($this->tokenEnabledFields as $f) {
-      $this->$f = token_replace($this->$f, $data);
+      $this->{$f} = token_replace($this->{$f}, $data, $options);
     }
   }
 

--- a/campaignion_email_to_target/tests/ActionTest.php
+++ b/campaignion_email_to_target/tests/ActionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\campaignion_email_to_target;
+
+use \Drupal\campaignion_action\TypeBase;
+use \Drupal\campaignion_email_to_target\Api\Client;
+use \Drupal\little_helpers\Webform\Submission;
+
+class ActionTest extends \DrupalUnitTestCase {
+
+  /**
+   * New Action with all methods mocked that would need database access.
+   */
+  protected function mockAction($targets) {
+    $api = $this->getMockBuilder(Client::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $api->method('getTargets')->will($this->returnValue($targets));
+    $node = (object) ['nid' => 47114711];
+    $type = new TypeBase('test');
+    $action = $this->getMockBuilder(Action::class)
+      ->setConstructorArgs([$type, $node, $api])
+      ->setMethods(['getOptions', 'getExclusion', 'getMessage'])
+      ->getMock();
+    $action->method('getOptions')->will($this->returnValue([
+      'dataset_name' => 'mp',
+    ]));
+    $submission_o = $this->getMockBuilder(Submission::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    return [$action, $api, $submission_o];
+  }
+
+  /**
+   * Create a message with the replaceTokens() method mocked.
+   */
+  protected function createMessage($data) {
+    return $this->getMockBuilder(Message::class)
+      ->setConstructorArgs([$data])
+      ->setMethods(['replaceTokens'])
+      ->getMock();
+  }
+
+  /**
+   * Test targetMessagePairs() with messages and all types of exclusions.
+   */
+  public function testTargetMessagePairs() {
+    $contacts = [
+      ['first_name' => 'Alice'],
+      ['first_name' => 'Bob'],
+      ['first_name' => 'Claire'],
+    ];
+    list($action, $api, $submission_o) = $this->mockAction([
+      [
+        'name' => 'Constituency 1',
+        'contacts' => $contacts,
+      ],
+      [
+        'name' => 'Excluded',
+        'contacts' => [
+          ['first_name' => 'David'],
+        ]
+      ],
+    ]);
+    $m = $this->createMessage([
+      'type' => 'message',
+      'label' => 'Default message',
+      'subject' => 'Default subject',
+      'header' => 'Default header',
+      'message' => 'Default message',
+      'footer' => 'Default footer',
+    ]);
+    $e = $this->createMessage([
+      'type' => 'exclusion',
+      'message' => 'excluded first!',
+    ]);
+    $action->method('getMessage')->will($this->returnCallback(function ($t, $c) use ($e, $m) {
+      if ($t['first_name'] == 'Bob') {
+        return $e;
+      }
+      return $m;
+    }));
+    $self = $this;
+    $action->method('getExclusion')->will($this->returnCallback(function ($c) use ($self) {
+      if ($c['name'] == 'Excluded') {
+        return $self->createMessage([
+          'type' => 'exclusion',
+          'message' => 'excluded!',
+        ]);
+      }
+    }));
+    list($pairs, $no_target_element) = $action->TargetMessagePairs($submission_o);
+    $this->assertEqual([[$contacts[0], $m], [$contacts[2], $m]], $pairs);
+    $this->assertEqual('excluded first!', $no_target_element);
+  }
+
+}
+

--- a/campaignion_email_to_target/tests/ComponentTest.php
+++ b/campaignion_email_to_target/tests/ComponentTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\campaignion_email_to_target;
+
+use \Drupal\campaignion_action\TypeBase;
+use \Drupal\campaignion_email_to_target\Api\Client;
+use \Drupal\little_helpers\Webform\Submission;
+use \Drupal\little_helpers\Webform\Webform;
+
+class ComponentTest extends \DrupalUnitTestCase {
+
+  /**
+   * New Component with all methods mocked that would need database access.
+   */
+  protected function mockComponent($pairs) {
+    $action = $this->getMockBuilder(Action::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['getOptions', 'targetMessagePairs'])
+      ->getMock();
+    $action->method('getOptions')->willReturn([
+      'dataset_name' => 'mp',
+      'user_may_edit' => TRUE,
+    ]);
+    $action->method('targetMessagePairs')->willReturn([$pairs, 'no target']);
+    $submission_o = $this->getMockBuilder(Submission::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $webform = $this->createMock(Webform::class);
+    $webform->method('formStateToSubmission')->willReturn($submission_o);
+    $component = new Component([
+      'name' => 'e2t',
+      'extra' => ['description' => 'e2t'],
+      'cid' => 7,
+    ], $webform, $action);
+    return [$component, $submission_o];
+  }
+
+  /**
+   * Test that escaping is only done for #markup attributes.
+   */
+  public function testRenderEscaping() {
+    list($component, $submission_o) = $this->mockComponent([
+      [['id' => 't1', 'salutation' => 'T1'], new Message([
+        'subject' => "Subject's string",
+        'header' => "Header's string",
+        'message' => "Message's string",
+        'footer' => "Footer's string",
+      ])]
+    ]);
+    $element = [];
+    $form = [];
+    $form_state = [];
+    $component->render($element, $form, $form_state);
+
+    $this->assertEqual("Subject's string", $element['t1']['subject']["#default_value"]);
+    $this->assertEqual("Header&#039;s string", $element['t1']['header']["#markup"]);
+    $this->assertEqual("Message's string", $element['t1']['message']["#default_value"]);
+    $this->assertEqual("Footer&#039;s string", $element['t1']['footer']["#markup"]);
+  }
+
+}

--- a/campaignion_email_to_target/tests/ComponentTest.php
+++ b/campaignion_email_to_target/tests/ComponentTest.php
@@ -49,13 +49,19 @@ class ComponentTest extends \DrupalUnitTestCase {
     ]);
     $element = [];
     $form = [];
-    $form_state = [];
+    $form_state = form_state_defaults();
     $component->render($element, $form, $form_state);
 
     $this->assertEqual("Subject's string", $element['t1']['subject']["#default_value"]);
     $this->assertEqual("Header&#039;s string", $element['t1']['header']["#markup"]);
     $this->assertEqual("Message's string", $element['t1']['message']["#default_value"]);
     $this->assertEqual("Footer&#039;s string", $element['t1']['footer']["#markup"]);
+
+    drupal_prepare_form('e2t_component_element', $element, $form_state);
+    drupal_process_form('e2t_component_element', $element, $form_state);
+    $rendered = drupal_render($element);
+    $this->assertTrue(strpos($rendered, "'") === FALSE, 'Unescaped output strings leaked to HTML output.');
+    $this->assertTrue(strpos($rendered, '&amp;') === FALSE, 'Some strings were double-escaped.');
   }
 
 }


### PR DESCRIPTION
* Fix double-escaping issues in the form element due to `token_replace()` + `check_plain()` in form components.
* Don't html-escape values that are used in plain-text emails.