### PR TITLE
Fix / refactor the supporter export

### DIFF
--- a/campaignion_manage/src/BatchJob.php
+++ b/campaignion_manage/src/BatchJob.php
@@ -51,6 +51,7 @@ class BatchJob {
     }
     $ids = $this->result->nextIds($context['sandbox']['current_id'], $this->batchSize);
     $contacts = redhen_contact_load_multiple($ids, array(), TRUE);
+    $batch->start($context);
     foreach ($contacts as $contact) {
       $batch->apply($contact, $context['results']);
       $context['sandbox']['current_id'] = $contact->contact_id;

--- a/campaignion_manage/src/BatchJob.php
+++ b/campaignion_manage/src/BatchJob.php
@@ -42,15 +42,12 @@ class BatchJob {
   }
 
   public function apply(&$context) {
-    static $batch = NULL;
     if (!isset($context['sandbox']['progress'])) {
       $this->init($context);
     }
-    if (!$batch) {
-      $batch = $this->bulkOp->getBatch($this->data);
-    }
     $ids = $this->result->nextIds($context['sandbox']['current_id'], $this->batchSize);
     $contacts = redhen_contact_load_multiple($ids, array(), TRUE);
+    $batch = $this->bulkOp->getBatch($this->data);
     $batch->start($context);
     foreach ($contacts as $contact) {
       $batch->apply($contact, $context['results']);

--- a/campaignion_manage/src/BulkOp/BatchBase.php
+++ b/campaignion_manage/src/BulkOp/BatchBase.php
@@ -4,6 +4,16 @@ namespace Drupal\campaignion_manage\BulkOp;
 
 class BatchBase {
   public function __construct(&$data) {}
+
+  /**
+   * Prepare for working on a new batch.
+   *
+   * @param array $context
+   *   The batch-API context.
+   */
+  public function start(&$context) {
+  }
+
   public function apply($contact, &$result) {}
   public function commit() {}
 }

--- a/campaignion_manage/src/BulkOp/BatchInterface.php
+++ b/campaignion_manage/src/BulkOp/BatchInterface.php
@@ -10,6 +10,7 @@ interface BatchInterface {
    *   Parameters for the bulk-operation.
    */
   public function getBatch(&$data);
+
   /**
    * @param array $data
    *   Parameters for the bulk-operation.

--- a/campaignion_manage/src/BulkOp/SupporterExportBatch.php
+++ b/campaignion_manage/src/BulkOp/SupporterExportBatch.php
@@ -6,14 +6,19 @@ use \Drupal\campaignion\ContactTypeManager;
 
 class SupporterExportBatch extends BatchBase {
   protected $exporter;
-  protected $file;
+  protected $file = NULL;
   protected $fields;
+  protected $filename;
 
   public function __construct(&$data) {
     $this->fields = $data['fields'];
-    $manager = ContactTypeManager::instance();
-    $this->exporter = $manager->exporter('campaignion_manage');
-    if (!($handle = fopen($data['csv_name'], 'a'))) {
+    $this->filename = $data['csv_name'];
+    $this->exporter = ContactTypeManager::instance()
+      ->exporter('campaignion_manage');
+  }
+
+  public function start(&$context) {
+    if (!($handle = fopen($this->filename, 'a'))) {
       $context['results']['errors'] = t('Couldn\'t open temporary file to export supporters.');
     }
     $this->file = $handle;

--- a/campaignion_manage/src/Query/Supporter.php
+++ b/campaignion_manage/src/Query/Supporter.php
@@ -23,6 +23,7 @@ class Supporter extends Base {
     $this->resultCalculated = NULL;
     $this->filtered = db_select('redhen_contact', 'r')
       ->fields('r', array('contact_id'))
+      ->condition('r.type', 'contact')
       ->distinct();
   }
   protected function calculateResult() {

--- a/campaignion_manage/src/ResultSet.php
+++ b/campaignion_manage/src/ResultSet.php
@@ -105,7 +105,7 @@ class ResultSet extends \Drupal\little_helpers\DB\Model {
 
   public function nextIds($start, $limit) {
     $filter = array(':id' => $this->id, ':start' => $start);
-    $result = db_query_range('SELECT contact_id FROM {campaignion_manage_result} WHERE meta_id=:id AND contact_id>:start', 0, $limit, $filter);
+    $result = db_query_range('SELECT contact_id FROM {campaignion_manage_result} WHERE meta_id=:id AND contact_id>:start ORDER BY contact_id', 0, $limit, $filter);
     return $result->fetchCol();
   }
 }


### PR DESCRIPTION
The actual bug was, that if multiple batches were handled in a single request, data would be written to an already closed file-handle. (commit was called after each batch, but the constructor only once.)