### PR TITLE
Add missing value parameter to _webform_csv_data_mc_interests().

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/campaignion_newsletters_mailchimp_interests/component.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/campaignion_newsletters_mailchimp_interests/component.php
@@ -119,7 +119,7 @@ function _webform_csv_headers_mc_interests($component, $export_options) {
 /**
  * Implements _webform_csv_headers_component.
  */
-function _webform_csv_data_mc_interests($component, $export_options) {
+function _webform_csv_data_mc_interests($component, $export_options, $value) {
   _webform_set_options_mc_interests($component);
-  return _webform_csv_data_select($component, $export_options);
+  return _webform_csv_data_select($component, $export_options, $value);
 }


### PR DESCRIPTION
Fixes an often occurring notice and perhaps also a malfunction (only empty values for exporting the newsletter component):

`Missing argument 3 for _webform_csv_data_select(), called in /var/www/drupal7/projects/campaignion-7.x-1.6/campaignion_newsletters/campaignion_newsletters_mailchimp/campaignion_newsletters_mailchimp_interests/component.php on line 124 and defined`