### PR TITLE
[mailchimp] Set status_if_new and avoid update/subscribe race conditions.

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/src/MailChimp.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/src/MailChimp.php
@@ -261,6 +261,7 @@ class MailChimp extends ProviderBase {
     $data = $this->preprocessData($item->data);
     $this->api->put("/lists/{$list->identifier}/members/$hash", [], [
       'email_address' => $item->email,
+      'status_if_new' => 'subscribed', // Updates don’t trigger opt-in emails.
     ] + $data);
   }
 

--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/tests/MailChimpTest.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/tests/MailChimpTest.php
@@ -69,7 +69,7 @@ class MailChimpTest extends \DrupalUnitTestCase {
     $subscription->expects($this->any())->method('newsletterList')
       ->will($this->returnValue(new NewsletterList([
         'list_id' => 2048,
-        'data' => (object) ['merge_vars' => $merge_vars],
+        'data' => (object) ['merge_vars' => $merge_vars, 'groups' => []],
       ])));
     return $subscription;
   }
@@ -271,6 +271,31 @@ class MailChimpTest extends \DrupalUnitTestCase {
       'merge_fields' => ['FNAME' => 'Fname'],
       'interests' => [],
     ], $data);
+  }
+
+  /**
+   * Test updating a contact.
+   */
+  public function testUpdate() {
+    list($api, $provider) = $this->mockChimp(['put']);
+    $item = new QueueItem([
+      'email' => 'test@example.com',
+      'data' => [],
+    ]);
+    $list = new NewsletterList([
+      'identifier' => 'test-list',
+    ]);
+    $api->expects($this->once())->method('put')->with(
+      $this->equalTo('/lists/test-list/members/55502f40dc8b7c769880b10874abc9d0'),
+      $this->equalTo([]),
+      $this->equalTo([
+        'email_address' => 'test@example.com',
+        'interests' => (object) [],
+        'merge_fields' => (object) [],
+        'status_if_new' => 'subscribed',
+      ])
+    );
+    $provider->update($list, $item);
   }
 
 }


### PR DESCRIPTION
Sometimes contact details were only transferred partially if the initial subscribe was overtaken by a successive update request.