### PR TITLE
Activities for newsletter subscriptions

### DIFF
--- a/campaignion_activity/campaignion_activity.install
+++ b/campaignion_activity/campaignion_activity.install
@@ -140,6 +140,43 @@ function campaignion_activity_schema() {
       ),
     ),
   );
+
+  $schema['campaignion_activity_newsletter_subscription'] = [
+    'description' => 'Track changes in newsletter subscriptions',
+    'fields' => [
+      'activity_id' => [
+        'description' => 'Foreign key to the activity.',
+      ] + $unsigned_int_not_null,
+      'list_id' => [
+        'description' => 'Foreign key to the newsletter list.',
+      ] + $unsigned_int_not_null,
+      'action' => [
+        'description' => 'Action (subscribe, unsubscribe, …)',
+        'type' => 'varchar',
+        'length' => '16',
+        'not null' => TRUE,
+      ],
+      'from_provider' => [
+        'description' => 'Flag for whether the change was initiated by the provider',
+      ] + $unsigned_int_not_null,
+    ],
+    'primary key' => ['activity_id'],
+    'indexes' => [
+      'newsletter_list' => ['list_id'],
+      'action' => ['action'],
+    ],
+    'foreign keys' => [
+      'activity' => [
+        'table' => 'campaignion_activity',
+        'columns' => ['activity_id' => 'activity_id'],
+      ],
+      'newsletter_list' => [
+        'table' => 'campaignion_newsletters_lists',
+        'columns' => ['list_id' => 'list_id'],
+      ],
+    ],
+  ];
+
   return $schema;
 }
 
@@ -148,6 +185,52 @@ function campaignion_activity_schema() {
  */
 function campaignion_activity_uninstall() {
   variable_del('campaignion_activity_log_contact_save');
+}
+
+/**
+ * Create table for newsletter activities.
+ */
+function campaignion_activity_update_4() {
+  $unsigned_int_not_null = array(
+    'type' => 'int',
+    'not null' => TRUE,
+    'unsigned' => TRUE,
+  );
+  db_create_table('campaignion_activity_newsletter_subscription', [
+    'description' => 'Track changes in newsletter subscriptions',
+    'fields' => [
+      'activity_id' => [
+        'description' => 'Foreign key to the activity.',
+      ] + $unsigned_int_not_null,
+      'list_id' => [
+        'description' => 'Foreign key to the newsletter list.',
+      ] + $unsigned_int_not_null,
+      'action' => [
+        'description' => 'Action (subscribe, unsubscribe, …)',
+        'type' => 'varchar',
+        'length' => '16',
+        'not null' => TRUE,
+      ],
+      'from_provider' => [
+        'description' => 'Flag for whether the change was initiated by the provider',
+      ] + $unsigned_int_not_null,
+    ],
+    'primary key' => ['activity_id'],
+    'indexes' => [
+      'newsletter_list' => ['list_id'],
+      'action' => ['action'],
+    ],
+    'foreign keys' => [
+      'activity' => [
+        'table' => 'campaignion_activity',
+        'columns' => ['activity_id' => 'activity_id'],
+      ],
+      'newsletter_list' => [
+        'table' => 'campaignion_newsletters_lists',
+        'columns' => ['list_id' => 'list_id'],
+      ],
+    ],
+  ]);
 }
 
 /**

--- a/campaignion_activity/campaignion_activity.module
+++ b/campaignion_activity/campaignion_activity.module
@@ -22,6 +22,9 @@ if (module_exists('webform')) {
     require_once dirname(__FILE__) . '/modules/webform_paymethod_select.php';
   }
 }
+if (module_exists('campaignion_newsletters')) {
+  require_once dirname(__FILE__) . '/modules/campaignion_newsletters.php';
+}
 
 /**
  * Implements hook_campaignion_activity_type_info().

--- a/campaignion_activity/modules/campaignion_newsletters.php
+++ b/campaignion_activity/modules/campaignion_newsletters.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations for tracking newsletters subscription changes.
+ */
+
+use \Drupal\campaignion_activity\NewsletterSubscription;
+use \Drupal\campaignion_newsletters\Subscription;
+
+/**
+ * Implements campaignion_newsletters_subscription_saved().
+ */
+function campaignion_activity_campaignion_newsletters_subscription_saved(Subscription $subscription, $from_provider, $was_new) {
+  if ($was_new) {
+    NewsletterSubscription::fromSubscription($subscription, 'subscribe', $from_provider)->save();
+  }
+}
+
+/**
+ * Implements campaignion_newsletters_subscription_deleted().
+ */
+function campaignion_activity_campaignion_newsletters_subscription_deleted(Subscription $subscription, $from_provider) {
+  NewsletterSubscription::fromSubscription($subscription, 'unsubscribe', $from_provider)->save();
+}

--- a/campaignion_activity/src/NewsletterSubscription.php
+++ b/campaignion_activity/src/NewsletterSubscription.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\campaignion_activity;
+
+use \Drupal\campaignion\ContactTypeManager;
+use \Drupal\campaignion\CRM\Import\Source\ArraySource;
+use \Drupal\campaignion_newsletters\Subscription;
+
+/**
+ * Partial model object to store newsletter subscription data for activities.
+ */
+class NewsletterSubscription extends ActivityBase {
+
+  protected $type = 'newsletter_subscription';
+
+  public $list_id;
+  public $action;
+  public $from_provider;
+
+  /**
+   * Create a new activity object from a subscription object.
+   *
+   * @param \Drupal\campaignion_newsletters\Subscription $subscription
+   *   The subscription object.
+   * @param string $action
+   *   The change made to the subscription (subscribe, unsubscribe).
+   * @param bool $from_provider
+   *   Whether this change was initiatey by the newsletter provider.
+   *
+   * @return static
+   */
+  public static function fromSubscription(Subscription $subscription, $action, $from_provider) {
+    $importer = ContactTypeManager::instance()->importer('campaignion_activity');
+    $source = new ArraySource(['email' => $subscription->email]);
+    $contact = $importer->findOrCreateContact($source);
+    return new static([
+      'contact_id' => $contact->contact_id,
+      'list_id' => $subscription->list_id,
+      'action' => $action,
+      'from_provider' => (int) $from_provider,
+    ]);
+  }
+
+  /**
+   * Load an activity by it’s id.
+   *
+   * @param int $activity_id
+   *   The ID of the activity to load.
+   */
+  public static function load($activity_id) {
+    $query = static::buildJoins();
+    $query->condition('a.activity_id', $activity_id);
+    return $query->execute()->fetchObject(static::class);
+  }
+
+  /**
+   * Build the database query for getting activities.
+   */
+  protected static function buildJoins() {
+    $query = db_select('campaignion_activity', 'a')
+      ->fields('a');
+    $query->innerJoin('campaignion_activity_newsletter_subscription', 'ans', 'ans.activity_id=a.activity_id');
+    $query->fields('ans');
+    return $query;
+  }
+
+  /**
+   * Save changes to the database.
+   */
+  protected function insert() {
+    parent::insert();
+    db_insert('campaignion_activity_newsletter_subscription')
+      ->fields($this->values([
+        'activity_id',
+        'list_id',
+        'action',
+        'from_provider',
+      ]))
+      ->execute();
+  }
+
+  /**
+   * Save changes to the database.
+   */
+  protected function update() {
+    parent::update();
+    db_update('campaignion_activity_newsletter_subscription')
+      ->fields($this->values(['list_id', 'action', 'from_provider']))
+      ->condition('activity_id', $this->activity_id)
+      ->execute();
+  }
+
+}

--- a/campaignion_activity/tests/NewsletterSubscriptionTest.php
+++ b/campaignion_activity/tests/NewsletterSubscriptionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\campaignion_activity;
+
+use \Drupal\campaignion_newsletters\Subscription;
+
+/**
+ * Test newsletter subscription activities.
+ */
+class NewsletterSubscriptionTest extends \DrupalWebTestCase{
+
+  public function setUp() {
+    parent::setUp(['campaignion_activity', 'campaignion_newsletters']);
+    db_delete('campaignion_activity')->execute();
+    db_delete('campaignion_activity_newsletter_subscription')->execute();
+  }
+
+  public function tearDown() {
+    db_delete('campaignion_newsletters_subscriptions')->execute();
+    db_delete('campaignion_newsletters_queue')->execute();
+    db_delete('campaignion_activity')->execute();
+    db_delete('campaignion_activity_newsletter_subscription')->execute();
+  }
+
+  public function test_saving_and_deleting_subscription() {
+    $email = 'bydataduplicate@test.com';
+    $list_id = 4711;
+    $s = Subscription::byData($list_id, $email);
+    $s->save();
+
+    $count = db_select('campaignion_activity_newsletter_subscription')
+      ->condition('list_id', 4711)
+      ->condition('action', 'subscribe')
+      ->countQuery()->execute()->fetchField();
+    $this->assertEqual(1, $count);
+
+    // Simulate provider delete
+    $s->delete(TRUE);
+
+    $count = db_select('campaignion_activity_newsletter_subscription')
+      ->condition('list_id', 4711)
+      ->condition('action', 'unsubscribe')
+      ->countQuery()->execute()->fetchField();
+    $this->assertEqual(1, $count);
+  }
+
+}

--- a/campaignion_newsletters/campaignion_newsletters.api.php
+++ b/campaignion_newsletters/campaignion_newsletters.api.php
@@ -11,9 +11,36 @@ use \Drupal\campaignion_newsletters\Subscription;
 
 /**
  * Alter a newsletter subscription prior to being saved.
+ *
+ * @param \Drupal\campaignion_newsletters\Subscription $subscription
+ *   The subscription that is going to be saved.
  */
 function hook_campaignion_newsletters_subscription_presave(Subscription $subscription) {
   if ($subscription->email == 'just-for-testing@example.com') {
     $subscription->delete = TRUE;
   }
+}
+
+/**
+ * React to a newsletter subscription being saved.
+ *
+ * @param \Drupal\campaignion_newsletters\Subscription $subscription
+ *   The subscription that was inserted into / updated in the database.
+ * @param bool $from_provider
+ *   TRUE if the change was initiated by the newsletter provider.
+ * @param bool $was_new
+ *   TRUE if the subscription was new.
+ */
+function hook_campaignion_newsletters_subscription_saved(Subscription $subscription, $from_provider, $was_new) {
+}
+
+/**
+ * React to a newsletter subscription being deleted.
+ *
+ * @param \Drupal\campaignion_newsletters\Subscription $subscription
+ *   The subscription that was delted from the database.
+ * @param bool $from_provider
+ *   TRUE if the change was initiated by the newsletter provider.
+ */
+function hook_campaignion_newsletters_subscription_saved(Subscription $subscription, $from_provider) {
 }

--- a/campaignion_newsletters/campaignion_newsletters_optivo/tests/SubscriberPollingTest.php
+++ b/campaignion_newsletters/campaignion_newsletters_optivo/tests/SubscriberPollingTest.php
@@ -44,8 +44,14 @@ class SubscriberPollingTest extends \DrupalUnitTestCase {
     ]);
     $this->list->save();
     $s = Subscription::fromData($this->list->list_id, 'test@example.com');
-    $s->updated = REQUEST_TIME - 30;
-    $s->save(TRUE, FALSE);
+    $s->save(TRUE);
+    // Set time so that last_sync is in the past.
+    $t = REQUEST_TIME - 30;
+    db_update('campaignion_newsletters_subscriptions')
+      ->fields(['updated' => $t, 'last_sync' => $t])
+      ->condition('email', $s->email)
+      ->condition('list_id', $s->list_id)
+      ->execute();
   }
 
   public function tearDown() {

--- a/campaignion_test/campaignion_test.module
+++ b/campaignion_test/campaignion_test.module
@@ -1,3 +1,11 @@
 <?php
 
 include_once 'campaignion_test.features.inc';
+
+/**
+ * Implements hook_campaignion_contact_info().
+ */
+function campaignion_test_campaignion_contact_type_info() {
+  $types['contact'] = '\\Drupal\\campaignion_test\\Supporter';
+  return $types;
+}


### PR DESCRIPTION
- Add new hooks for campaignion_newsletters.
- Implement those hooks in campaignion_activity.
- Add a new newsletter_subscription activity type (including model and
  code to track the activities).