### PR TITLE
Fix confirmation email always created for new actions.

### DIFF
--- a/campaignion_wizard/src/ConfirmationEmail.php
+++ b/campaignion_wizard/src/ConfirmationEmail.php
@@ -39,9 +39,6 @@ class ConfirmationEmail extends Email {
     // Silence the message set by webform_confirm_email_settings_submit().
     $messages = isset($_SESSION['messages']) ? $_SESSION['messages'] : NULL;
     $element = $form[$this->form_id . '_email'];
-    // Update the node with the modified email otherwise node_save() reverts our
-    // changes immediately.
-    $this->node->webform['emails'][$this->eid] = webform_email_load($this->eid, $this->node->nid);
     webform_confirm_email_settings_submit($element, $form_state);
     if (is_null($messages)) {
       unset($_SESSION['messages']);

--- a/campaignion_wizard/src/Email.php
+++ b/campaignion_wizard/src/Email.php
@@ -227,6 +227,10 @@ class Email {
       ))
       ->fields(array('email_type' => $email_type))
       ->execute();
+    // Update the node with the modified email otherwise a subsequent
+    // node_save() reverts our changes immediately.
+    $email = webform_email_load($this->eid, $this->node->nid);
+    $this->node->webform['emails'][$this->eid] = $email;
   }
 
   protected function deleteEmail() {


### PR DESCRIPTION
Update the node object right after saving a webform email.