### PR TITLE
[mailchimp] Uprade webhook handling to current API version.

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/campaignion_newsletters_mailchimp.module
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/campaignion_newsletters_mailchimp.module
@@ -20,6 +20,7 @@ function campaignion_newsletters_mailchimp_menu() {
     'access callback' => 'campaignion_newsletters_mailchimp_webhook_access',
     'access arguments' => [1, 2],
     'type' => MENU_CALLBACK,
+    'delivery callback' => 'little_helpers_deliver_json',
   ];
 
   return $items;
@@ -81,7 +82,5 @@ function campaignion_newsletters_mailchimp_webhook($list_id) {
         break;
     }
   }
-  echo 'OK';
-  drupal_page_footer();
-  drupal_exit();
+  return ['status' => 'OK'];
 }

--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/campaignion_newsletters_mailchimp.module
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/campaignion_newsletters_mailchimp.module
@@ -71,7 +71,17 @@ function campaignion_newsletters_mailchimp_webhook_access($list_id, $hash) {
  * Page callback for MailChimps webhooks.
  */
 function campaignion_newsletters_mailchimp_webhook($list_id) {
-  if (!empty($_POST['data']) && $_POST['data']['action'] === 'unsub') {
-    Subscription::byData($list_id, $_POST['data']['email'])->delete(TRUE);
+  if (!empty($_POST['type'])) {
+    switch ($_POST['type']) {
+      case 'unsubscribe':
+      case 'cleaned':
+        if (!empty($_POST['data']['email'])) {
+          Subscription::byData($list_id, $_POST['data']['email'])->delete(TRUE);
+        }
+        break;
+    }
   }
+  echo 'OK';
+  drupal_page_footer();
+  drupal_exit();
 }

--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/tests/WebhookTest.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/tests/WebhookTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\campaignion_newsletters_mailchimp;
+
+use Drupal\campaignion_newsletters\Subscription;
+
+/**
+ * Test the webhook.
+ */
+class WebhookTest extends \DrupalWebTestCase {
+
+  public function setUp() {
+    $this->subscription = Subscription::byData(4711, 'mc-webhook-test@example.com');
+    $this->subscription->save(TRUE);
+    $this->post = $_POST;
+  }
+
+  /**
+   * Test an unsubscribe via MailChimp.
+   */
+  public function testWebhookUnsubscribe() {
+    $_POST = [
+      'type' => 'unsubscribe',
+      'data' => ['email' => 'mc-webhook-test@example.com'],
+    ];
+    $answer = campaignion_newsletters_mailchimp_webhook(4711);
+    // Check that the subscription was deleted by the webhook.
+    $this->assertTrue(Subscription::byData(4711, 'mc-webhook-test@example.com')->isNew());
+    $this->assertEqual(['status' => 'OK'], $answer);
+  }
+
+  /**
+   * Test a test request from MailChimp.
+   *
+   * MailChimp pings the webhook with a GET-request to test it’s availability.
+   */
+  public function testWebhookGet() {
+    $answer = campaignion_newsletters_mailchimp_webhook(4711);
+    $this->assertFalse(Subscription::byData(4711, 'mc-webhook-test@example.com')->isNew());
+    $this->assertEqual(['status' => 'OK'], $answer);
+  }
+
+  public function tearDown() {
+    $_POST = $this->post;
+    $this->subscription->delete();
+  }
+
+}
+

--- a/campaignion_test/campaignion_test.info
+++ b/campaignion_test/campaignion_test.info
@@ -7,6 +7,7 @@ dependencies[] = campaignion
 dependencies[] = campaignion_action
 dependencies[] = campaignion_activity
 dependencies[] = campaignion_newsletters
+dependencies[] = campaignion_newsletters_mailchimp
 dependencies[] = campaignion_supporter_tags
 dependencies[] = campaignion_email_to_target
 dependencies[] = campaignion_webform_tokens


### PR DESCRIPTION
We seem to have missed an API change here. This makes 'unsubscribe' and
'cleaned' events work according to:
https://developer.mailchimp.com/documentation/mailchimp/guides/about-webhooks/