### PR TITLE
[campaignion_donation] variable for recurrent direct debit

### DIFF
--- a/campaignion_donation/campaignion_donation.info
+++ b/campaignion_donation/campaignion_donation.info
@@ -4,4 +4,5 @@ core = 7.x
 package = Campaignion
 dependencies[] = campaignion_action
 dependencies[] = form_builder_webform
+dependencies[] = variable
 dependencies[] = webform_paymethod_select (>= 7.x-1.8)

--- a/campaignion_donation/campaignion_donation.install
+++ b/campaignion_donation/campaignion_donation.install
@@ -7,6 +7,15 @@
  */
 
 /**
+ * Introduce a variable.
+ */
+function campaignion_donation_update_2() {
+  if (!module_enable(['variable'], TRUE)) {
+    throw new DrupalUpdateException('Could not enable the variable module.');
+  }
+}
+
+/**
  * Enable the campaignion_donation_type.
  */
 function campaignion_donation_update_1() {

--- a/campaignion_donation/campaignion_donation.module
+++ b/campaignion_donation/campaignion_donation.module
@@ -31,7 +31,7 @@ function campaignion_donation_webform_paymethod_select_method_list_alter(&$metho
       }
     }
   }
-  else {
+  elseif (!variable_get_value('campaignion_donation_manual_direct_debit_one_off')) {
     foreach ($methods as $pmid => $method) {
       if ($method->name == 'manual_direct_debit') {
         unset($methods[$pmid]);

--- a/campaignion_donation/campaignion_donation.variable.inc
+++ b/campaignion_donation/campaignion_donation.variable.inc
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Hook implementation for the variable module.
+ */
+
+/**
+ * Implements hook_variable_info().
+ */
+function campaignion_donation_variable_info() {
+  $info['campaignion_donation_manual_direct_debit_one_off'] = [
+    'title' => t('Manual direct debit donation one-off allowed'),
+    'description' => t('Whether manual direct debit is available for one-off payments.'),
+    'type' => 'boolean',
+    'default' => FALSE,
+  ];
+  return $info;
+}


### PR DESCRIPTION
- introduce variable to configure whether manual direct debit should be
  allowed for one-off donations too
- the default is/was to only allow it for recurrent donations