### PR TITLE
Add missing field_base:supporter_tags.

### DIFF
--- a/campaignion_supporter_tags/campaignion_supporter_tags.features.field_base.inc
+++ b/campaignion_supporter_tags/campaignion_supporter_tags.features.field_base.inc
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @file
+ * campaignion_supporter_tags.features.field_base.inc
+ */
+
+/**
+ * Implements hook_field_default_field_bases().
+ */
+function campaignion_supporter_tags_field_default_field_bases() {
+  $field_bases = array();
+
+  // Exported field_base: 'supporter_tags'.
+  $field_bases['supporter_tags'] = array(
+    'active' => 1,
+    'cardinality' => -1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'supporter_tags',
+    'global_block_settings' => 1,
+    'indexes' => array(
+      'tid' => array(
+        0 => 'tid',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'taxonomy',
+    'settings' => array(
+      'allowed_values' => array(
+        0 => array(
+          'vocabulary' => 'supporter_tags',
+          'parent' => 0,
+        ),
+      ),
+      'options_list_callback' => 'i18n_taxonomy_allowed_values',
+      'profile2_private' => FALSE,
+    ),
+    'translatable' => 0,
+    'type' => 'taxonomy_term_reference',
+  );
+
+  return $field_bases;
+}

--- a/campaignion_supporter_tags/campaignion_supporter_tags.info
+++ b/campaignion_supporter_tags/campaignion_supporter_tags.info
@@ -1,3 +1,4 @@
+name = Campaignion supporter tags
 description = Adds field for handling supporter tags with actions pages.
 core = 7.x
 package = Campaignion
@@ -9,3 +10,4 @@ dependencies[] = strongarm
 dependencies[] = taxonomy
 features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2
+features[field_base][] = supporter_tags


### PR DESCRIPTION
The field is used in the campaignion_supporter_tags module so the field_base should be declared there. This was simply missed by the previous pull requests.