### PR TITLE
3-state optins: subscribe / unsubscribe / no change

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -121,16 +121,16 @@ function _webform_edit_newsletter($component) {
   $form['extra']['radio_labels'] = [
     '#tree' => TRUE, // Needed for form_builder.
     '#type' => 'fieldset',
-    '#title' => t('Labels for the radios'),
+    '#title' => t('Labels for the radios.'),
     '#states' => ['visible' => ["#$display_id" => ['value' => 'radios']]],
     1 => [
       '#type' => 'textfield',
-      '#title' => t('Yes'),
+      '#title' => t('Subscribe'),
       '#default_value' => $component['extra']['radio_labels'][1],
     ],
     0 => [
       '#type' => 'textfield',
-      '#title' => t('No'),
+      '#title' => t('Unsubscribe'),
       '#default_value' => $component['extra']['radio_labels'][0],
     ],
   ];
@@ -189,11 +189,34 @@ function _webform_submit_newsletter($component, $value) {
   switch ($component['extra']['display']) {
     case 'checkbox':
       return empty($value['subscribed']) ? [''] : ['subscribed'];
-      break;
 
     case 'radios':
-      return $value == 'yes' ? ['subscribed'] : [''];
-      break;
+      switch ($value) {
+        case 'yes':
+          return ['subscribed'];
+        case 'no':
+          return ['unsubscribed'];
+        default:
+          return [''];
+      }
+  }
+}
+
+/**
+ * Helper function to create display labels for stored values.
+ */
+function _webform_newsletter_value_to_label($value) {
+  if (!$value) {
+    return t('not subscribed');
+  }
+  $value = reset($value);
+  switch ($value) {
+    case 'subscribed':
+      return t('subscribed');
+    case 'unsubscribed':
+      return t('unsubscribed');
+    default:
+      return t('not subscribed');
   }
 }
 
@@ -201,7 +224,7 @@ function _webform_submit_newsletter($component, $value) {
  * Implements _webform_display_component().
  */
 function _webform_display_newsletter($component, $value, $format = 'html') {
-  $v['#markup'] = !empty($value[0]) ? t('subscribed') : t('not subscribed');
+  $v['#markup'] = _webform_newsletter_value_to_label($value);
   return $v;
 }
 
@@ -310,7 +333,7 @@ function _webform_form_builder_map_newsletter() {
  * Implements _webform_table_component().
  */
 function _webform_table_newsletter($component, $value) {
-  return $value && reset($value) ? t('subscribed') : t('not subscribed');
+  return _webform_newsletter_value_to_label($value);
 }
 
 /**
@@ -328,5 +351,5 @@ function _webform_csv_headers_newsletter($component, $export_options) {
  * Implements _webform_csv_data_component().
  */
 function _webform_csv_data_newsletter($component, $export_options, $value) {
-  return $value && reset($value) ? t('subscribed') : t('not subscribed');
+  return _webform_newsletter_value_to_label($value);
 }

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -96,10 +96,11 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
     return;
   }
   foreach ($s->webform->componentsByType('newsletter') as $component) {
-    if ($s->valueByCid($component['cid'])) {
+    $value = $s->valueByCid($component['cid']);
+    if ($value == 'subscribed') {
       $needs_opt_in = !$component['extra']['opt_in_implied'];
-      foreach ($component['extra']['lists'] as $list_id => $value) {
-        if (!empty($value)) {
+      foreach ($component['extra']['lists'] as $list_id => $enabled) {
+        if (!empty($enabled)) {
           $subscription = Subscription::byData($list_id, $email);
           $subscription->delete = FALSE;
           $subscription->source = $s;
@@ -108,6 +109,11 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
           $subscription->optin_info = FormSubmission::fromWebformSubmission($s);
           $subscription->save();
         }
+      }
+    }
+    elseif ($value == 'unsubscribed') {
+      foreach (Subscription::byEmail($email) as $subscription) {
+        $subscription->delete();
       }
     }
   }

--- a/campaignion_newsletters/tests/ComponentTest.php
+++ b/campaignion_newsletters/tests/ComponentTest.php
@@ -23,13 +23,17 @@ class ComponentTest extends \DrupalUnitTestCase {
   public function testSubmitRadios() {
     $c['extra']['display'] = 'radios';
 
-    // Not checked checkbox.
+    // Radio no.
     $v = 'no';
-    $this->assertEqual([''], _webform_submit_newsletter($c, $v));
+    $this->assertEqual(['unsubscribed'], _webform_submit_newsletter($c, $v));
 
-    // Checked checkbox.
+    // Radio yes.
     $v = 'yes';
     $this->assertEqual(['subscribed'], _webform_submit_newsletter($c, $v));
+
+    // Not selected radio.
+    $v = NULL;
+    $this->assertEqual([''], _webform_submit_newsletter($c, $v));
   }
 
   public function testTable() {


### PR DESCRIPTION
* Changes how values are stored:
  * 'subscribed': checkbox checked OR radio yes [unchanged]
  * 'unsubscribed': radio no [NEW]
  * '': checkbox not checked OR radio not selected [unchanged]
* When the value is 'unsubscribed' the email address is unsubscribed
  from all known lists.

This will be made configurable in the future, but it’s enough for some
special cases for the while.