### PR TITLE
3-state optins: subsribe/unsubscribe/no change

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -238,7 +238,7 @@ function _webform_submit_newsletter($component, $value) {
  */
 function _webform_newsletter_value_to_label($value) {
   if (!$value) {
-    return t('not subscribed');
+    return t('no change');
   }
   $value = reset($value);
   switch ($value) {
@@ -247,7 +247,7 @@ function _webform_newsletter_value_to_label($value) {
     case 'unsubscribed':
       return t('unsubscribed');
     default:
-      return t('not subscribed');
+      return t('no change');
   }
 }
 

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -260,118 +260,15 @@ function _webform_display_newsletter($component, $value, $format = 'html') {
 }
 
 /**
- * Form callback for the newsletter property.
- *
- * @see _webform_form_builder_map_newsletter()
- */
-function campaignion_newsletters_form_builder_property_newsletter_form(&$form_state, $form_type, $element, $property) {
-  $form['options'] = array(
-    '#form_builder' => array('property_group' => 'options'),
-    '#tree' => TRUE,
-  );
-  $edit = _webform_edit_newsletter($element['#webform_component']);
-  $form['options']['lists'] = $edit['extra']['lists'];
-  $form['newsletter_title'] = $edit['extra']['description'];
-  $form['newsletter_value'] = $edit['value'];
-  $form['newsletter_opt_in_implied'] = $edit['extra']['opt_in_implied'];
-  $form['newsletter_send_welcome'] = $edit['extra']['send_welcome'];
-  $dp['#form_builder']['property_group'] = 'display';
-  $form['newsletter_display'] = $edit['extra']['display'] + $dp;
-  $form['newsletter_checkbox_label'] = $edit['extra']['checkbox_label'] + $dp;
-  $form['newsletter_radio_labels'] = $edit['extra']['radio_labels'] + $dp;
-  $form['newsletter_optin_statement'] = $edit['extra']['optin_statement'];
-  $form['newsletter_no_is_optout'] = $edit['extra']['no_is_optout'];
-  $form['newsletter_optout_all_lists'] = $edit['extra']['optout_all_lists'];
-
-  return $form;
-}
-
-/**
- * Submit handler for the newsletter property.
- *
- * @see _webform_form_builder_map_newsletter()
- */
-function campaignion_newsletters_form_builder_property_newsletter_form_submit(&$form, &$form_state) {
-  $form_state['values']['newsletter_lists'] = $form_state['values']['options']['lists'];
-}
-
-/**
- * Implements _webform_form_builder_properties_component().
- *
- * Component specific properties.
- * This is currently broken as the component specific properties are merged into
- * the global property list. That makes it behave the same way as an
- * implementation of hook_form_builder_properties().
- *
- * @see form_builder_webform_form_builder_properties()
- */
-function _webform_form_builder_properties_newsletter() {
-  return array(
-    'newsletter_lists' => array(
-      'form' => 'campaignion_newsletters_form_builder_property_newsletter_form',
-      'submit' => array('campaignion_newsletters_form_builder_property_newsletter_form_submit'),
-    ),
-    'newsletter_title' => array(),
-    'newsletter_opt_in_implied' => array(),
-    'newsletter_send_welcome' => [],
-    'newsletter_display' => [],
-    'newsletter_radio_labels' => [],
-    'newsletter_checkbox_label' => [],
-    'newsletter_optin_statement' => [],
-    'newsletter_optin_no_is_optout' => [],
-    'newsletter_optin_optout_all_lists' => [],
-  );
-}
-
-/**
  * Implements _webform_CALLBACK_TYPE().
  *
  * Implements _webform_form_builder_map_TYPE().
- *
- * Defines mapping from webform component to form_builder element type.
- * Tell form_builder_webform how to store properties:
- * $form_state['values']['newsletter'] -> $component['value'].
  *
  * This hook allows us to extend the list of properties defined in
  * hook_form_builder_element_types() specific for form_builder_webform.
  */
 function _webform_form_builder_map_newsletter() {
   $map['form_builder_type'] = 'newsletter';
-  $map['properties'] = array(
-    'newsletter_lists' => array(
-      'storage_parents' => array('extra', 'lists'),
-    ),
-    'newsletter_title' => array(
-      'storage_parents' => array('extra', 'description'),
-    ),
-    'newsletter_opt_in_implied' => array(
-      'storage_parents' => array('extra', 'opt_in_implied'),
-    ),
-    'newsletter_send_welcome' => array(
-      'storage_parents' => array('extra', 'send_welcome'),
-    ),
-    'newsletter_value' => array(
-      'storage_parents' => array('value'),
-    ),
-    'newsletter_display' => [
-      'storage_parents' => ['extra', 'display'],
-    ],
-    'newsletter_radio_labels' => [
-      'storage_parents' => ['extra', 'radio_labels'],
-    ],
-    'newsletter_checkbox_label' => [
-      'storage_parents' => ['extra', 'checkbox_label'],
-    ],
-    'newsletter_optin_statement' => [
-      'storage_parents' => ['extra', 'optin_statement'],
-    ],
-    'newsletter_no_is_optout' => [
-      'storage_parents' => ['extra', 'no_is_optout'],
-    ],
-    'newsletter_optout_all_lists' => [
-      'storage_parents' => ['extra', 'optout_all_lists'],
-    ],
-  );
   return $map;
 }
 

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -63,6 +63,7 @@ function _webform_edit_newsletter($component) {
     '#title' => t('Description'),
     '#default_value' => $component['extra']['description'],
     '#weight' => 0,
+    '#parents' => ['extra', 'description'],
   );
 
   $form['value'] = array(
@@ -71,6 +72,7 @@ function _webform_edit_newsletter($component) {
     '#options' => array('subscribed' => t('The newsletter checkbox is checked by default.')),
     '#default_value' => $component['value'],
     '#element_validate' => array('_webform_value_validate_newsletter'),
+    '#parents' => ['value'],
   );
 
   natcasesort($newsletters);
@@ -85,6 +87,7 @@ function _webform_edit_newsletter($component) {
     '#empty_option' => t('Select newsletters'),
     '#multiple' => 1,
     '#select2' => array(),
+    '#parents' => ['extra', 'lists'],
   );
 
   $form['extra']['opt_in_implied'] = array(
@@ -95,12 +98,14 @@ function _webform_edit_newsletter($component) {
       0 => t("Newsletter provider: This form doesn't provide double-opt-in functionality the newsletter provider should take care of it."),
       1 => t('Included in this form: This form includes a double-opt-in process no further action is needed'),
     ),
+    '#parents' => ['extra', 'opt_in_implied'],
   );
 
   $form['extra']['send_welcome'] = array(
     '#type' => 'checkbox',
     '#title' => t('Send a welcome email (for new subscribers).'),
     '#default_value' => !empty($component['extra']['send_welcome']),
+    '#parents' => ['extra', 'send_welcome'],
   );
 
   $display_id = drupal_html_id('newsletter-display');
@@ -113,6 +118,7 @@ function _webform_edit_newsletter($component) {
     ),
     '#default_value' => $component['extra']['display'],
     '#id' => $display_id,
+    '#parents' => ['extra', 'display'],
   ];
 
   $form['extra']['checkbox_label'] = [
@@ -120,6 +126,7 @@ function _webform_edit_newsletter($component) {
     '#title' => t('Label for the checkbox'),
     '#default_value' => $component['extra']['checkbox_label'],
     '#states' => ['visible' => ["#$display_id" => ['value' => 'checkbox']]],
+    '#parents' => ['extra', 'checkbox_label'],
   ];
 
   $form['extra']['radio_labels'] = [
@@ -138,12 +145,14 @@ function _webform_edit_newsletter($component) {
       '#title' => t('Unsubscribe'),
       '#default_value' => $component['extra']['radio_labels'][0],
     ],
+    '#parents' => ['extra', 'radio_labels'],
   ];
 
   $form['extra']['optin_statement'] = [
     '#type' => 'textarea',
     '#title' => t('Opt-in statement'),
     '#default_value' => $component['extra']['optin_statement'],
+    '#parents' => ['extra', 'optin_statement'],
   ];
 
   $optout_id = drupal_html_id('newsletter-no-is-optout');
@@ -152,6 +161,7 @@ function _webform_edit_newsletter($component) {
     '#title' => t('No (radio) is taken as opt-out'),
     '#default_value' => !empty($component['extra']['no_is_optout']),
     '#id' => $optout_id,
+    '#parents' => ['extra', 'no_is_optout'],
   ];
 
   $form['extra']['optout_all_lists'] = [
@@ -159,6 +169,7 @@ function _webform_edit_newsletter($component) {
     '#title' => t('On opt-out: Remove all subscriptions for this email address.'),
     '#default_value' => !empty($component['extra']['optout_all_lists']),
     '#states' => ['visible' => ["#$optout_id" => ['checked' => TRUE]]],
+    '#parents' => ['extra', 'optout_all_lists'],
   ];
 
   return $form;

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -124,16 +124,16 @@ function _webform_edit_newsletter($component) {
     // Needed for form_builder.
     '#tree' => TRUE,
     '#type' => 'fieldset',
-    '#title' => t('Labels for the radios'),
+    '#title' => t('Labels for the radios.'),
     '#states' => ['visible' => ["#$display_id" => ['value' => 'radios']]],
     1 => [
       '#type' => 'textfield',
-      '#title' => t('Yes'),
+      '#title' => t('Subscribe'),
       '#default_value' => $component['extra']['radio_labels'][1],
     ],
     0 => [
       '#type' => 'textfield',
-      '#title' => t('No'),
+      '#title' => t('Unsubscribe'),
       '#default_value' => $component['extra']['radio_labels'][0],
     ],
   ];
@@ -204,8 +204,32 @@ function _webform_submit_newsletter($component, $value) {
       return empty($value['subscribed']) ? [''] : ['subscribed'];
 
     case 'radios':
-      return $value == 'yes' ? ['subscribed'] : [''];
+      switch ($value) {
+        case 'yes':
+          return ['subscribed'];
+        case 'no':
+          return ['unsubscribed'];
+        default:
+          return [''];
+      }
+  }
+}
 
+/**
+ * Helper function to create display labels for stored values.
+ */
+function _webform_newsletter_value_to_label($value) {
+  if (!$value) {
+    return t('not subscribed');
+  }
+  $value = reset($value);
+  switch ($value) {
+    case 'subscribed':
+      return t('subscribed');
+    case 'unsubscribed':
+      return t('unsubscribed');
+    default:
+      return t('not subscribed');
   }
 }
 
@@ -213,7 +237,7 @@ function _webform_submit_newsletter($component, $value) {
  * Implements _webform_display_component().
  */
 function _webform_display_newsletter($component, $value, $format = 'html') {
-  $v['#markup'] = !empty($value[0]) ? t('subscribed') : t('not subscribed');
+  $v['#markup'] = _webform_newsletter_value_to_label($value);
   return $v;
 }
 
@@ -327,7 +351,7 @@ function _webform_form_builder_map_newsletter() {
  * Implements _webform_table_component().
  */
 function _webform_table_newsletter($component, $value) {
-  return $value && reset($value) ? t('subscribed') : t('not subscribed');
+  return _webform_newsletter_value_to_label($value);
 }
 
 /**
@@ -345,7 +369,7 @@ function _webform_csv_headers_newsletter($component, $export_options) {
  * Implements _webform_csv_data_component().
  */
 function _webform_csv_data_newsletter($component, $export_options, $value) {
-  return $value && reset($value) ? t('subscribed') : t('not subscribed');
+  return _webform_newsletter_value_to_label($value);
 }
 
 /**

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -31,6 +31,8 @@ function _webform_defaults_newsletter() {
       'radio_labels' => [t('No'), t('Yes, I want to subscribe to the newsletter')],
       'checkbox_label' => t('Subscribe me to the newsletter.'),
       'optin_statement' => '',
+      'no_is_optout' => FALSE,
+      'optout_all_lists' => TRUE,
     ),
   );
 }
@@ -144,6 +146,21 @@ function _webform_edit_newsletter($component) {
     '#default_value' => $component['extra']['optin_statement'],
   ];
 
+  $optout_id = drupal_html_id('newsletter-no-is-optout');
+  $form['extra']['no_is_optout'] = [
+    '#type' => 'checkbox',
+    '#title' => t('No (radio) is taken as opt-out'),
+    '#default_value' => !empty($component['extra']['no_is_optout']),
+    '#id' => $optout_id,
+  ];
+
+  $form['extra']['optout_all_lists'] = [
+    '#type' => 'checkbox',
+    '#title' => t('On opt-out: Remove all subscriptions for this email address.'),
+    '#default_value' => !empty($component['extra']['optout_all_lists']),
+    '#states' => ['visible' => ["#$optout_id" => ['checked' => TRUE]]],
+  ];
+
   return $form;
 }
 
@@ -184,7 +201,8 @@ function _webform_render_newsletter($component, $value = NULL, $filter = TRUE) {
 
     case 'radios':
       $l = $component['extra']['radio_labels'];
-      $options = ['yes' => $l[1], 'no' => $l[0]];
+      $no_value = !empty($component['extra']['no_is_optout']) ? 'no' : '';
+      $options = ['yes' => $l[1], $no_value => $l[0]];
       $element += [
         '#type' => 'radios',
         '#default_value' => !empty($component['value']['subscribed']) ? 'yes' : NULL,
@@ -262,6 +280,8 @@ function campaignion_newsletters_form_builder_property_newsletter_form(&$form_st
   $form['newsletter_checkbox_label'] = $edit['extra']['checkbox_label'] + $dp;
   $form['newsletter_radio_labels'] = $edit['extra']['radio_labels'] + $dp;
   $form['newsletter_optin_statement'] = $edit['extra']['optin_statement'];
+  $form['newsletter_no_is_optout'] = $edit['extra']['no_is_optout'];
+  $form['newsletter_optout_all_lists'] = $edit['extra']['optout_all_lists'];
 
   return $form;
 }
@@ -298,6 +318,8 @@ function _webform_form_builder_properties_newsletter() {
     'newsletter_radio_labels' => [],
     'newsletter_checkbox_label' => [],
     'newsletter_optin_statement' => [],
+    'newsletter_optin_no_is_optout' => [],
+    'newsletter_optin_optout_all_lists' => [],
   );
 }
 
@@ -343,6 +365,12 @@ function _webform_form_builder_map_newsletter() {
     'newsletter_optin_statement' => [
       'storage_parents' => ['extra', 'optin_statement'],
     ],
+    'newsletter_no_is_optout' => [
+      'storage_parents' => ['extra', 'no_is_optout'],
+    ],
+    'newsletter_optout_all_lists' => [
+      'storage_parents' => ['extra', 'optout_all_lists'],
+    ],
   );
   return $map;
 }
@@ -377,9 +405,14 @@ function _webform_csv_data_newsletter($component, $export_options, $value) {
  */
 function _webform_conditional_comparison_newsletter_equal(array $input_values, $rule_value, array $component) {
   if (!$input_values) {
-    return $rule_value == 'no';
+    return $rule_value == '';
   }
-  $look_for = $rule_value == 'yes' ? ['subscribed', 'yes'] : [0, 'no', ''];
+  $look_for_map = [
+    '' => [0, ''],
+    'yes' => ['subscribed', 'yes'],
+    'no' => ['unsubscribed', 'no'],
+  ];
+  $look_for = $look_for_map[$rule_value];
   foreach ($input_values as $value) {
     if (in_array($value, $look_for, TRUE)) {
       return TRUE;

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -156,12 +156,12 @@ function _webform_edit_newsletter($component) {
     '#states' => ['visible' => ["#$display_id" => ['value' => 'radios']]],
     1 => [
       '#type' => 'textfield',
-      '#title' => t('Subscribe'),
+      '#title' => t('Yes'),
       '#default_value' => $component['extra']['radio_labels'][1],
     ],
     0 => [
       '#type' => 'textfield',
-      '#title' => t('Unsubscribe'),
+      '#title' => t('No'),
       '#default_value' => $component['extra']['radio_labels'][0],
     ],
     '#parents' => ['extra', 'radio_labels'],

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -58,6 +58,11 @@ function _webform_edit_newsletter($component) {
     ->execute()
     ->fetchAllKeyed();
 
+  $form['behavior'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Behavior'),
+  ];
+
   $form['extra']['description'] = array(
     '#type' => 'textarea',
     '#title' => t('Description'),
@@ -66,23 +71,27 @@ function _webform_edit_newsletter($component) {
     '#parents' => ['extra', 'description'],
   );
 
-  $form['value'] = array(
+  $form['behavior']['value'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Default state'),
-    '#options' => array('subscribed' => t('The newsletter checkbox is checked by default.')),
+    '#options' => array('subscribed' => t('The newsletter checkbox is checked by default, the radio default is set to “Yes”.')),
     '#default_value' => $component['value'],
     '#element_validate' => array('_webform_value_validate_newsletter'),
     '#parents' => ['value'],
   );
 
+  $form['list_management'] = [
+    '#type' => 'fieldset',
+    '#title' => t('List management'),
+  ];
+
   natcasesort($newsletters);
-  $form['extra']['lists'] = array(
+  $form['list_management']['lists'] = array(
     '#type' => module_exists('select2') && count($newsletters) > 5 ? 'select' : 'checkboxes',
     '#title' => t('Newsletter'),
     '#default_value' => $component['extra']['lists'],
     '#description' => t('Which lists should the user be subscribed to?'),
     '#options' => $newsletters,
-    '#weight' => 1,
     // Only relevant if type is 'select':
     '#empty_option' => t('Select newsletters'),
     '#multiple' => 1,
@@ -90,7 +99,7 @@ function _webform_edit_newsletter($component) {
     '#parents' => ['extra', 'lists'],
   );
 
-  $form['extra']['opt_in_implied'] = array(
+  $form['list_management']['opt_in_implied'] = array(
     '#type' => 'radios',
     '#title' => t('Double opt-in'),
     '#default_value' => $component['extra']['opt_in_implied'],
@@ -101,7 +110,17 @@ function _webform_edit_newsletter($component) {
     '#parents' => ['extra', 'opt_in_implied'],
   );
 
-  $form['extra']['send_welcome'] = array(
+
+  $form['list_management']['welcome'] = [
+    '#type' => 'container',
+    '#attributes' => ['class' => ['form-item']],
+  ];
+  $form['list_management']['welcome']['label'] = [
+    '#theme' => 'form_element_label',
+    '#title' => t('Welcome email'),
+    '#title_display' => 'before',
+  ];
+  $form['list_management']['welcome']['enabled'] = array(
     '#type' => 'checkbox',
     '#title' => t('Send a welcome email (for new subscribers).'),
     '#default_value' => !empty($component['extra']['send_welcome']),
@@ -151,24 +170,29 @@ function _webform_edit_newsletter($component) {
   $form['extra']['optin_statement'] = [
     '#type' => 'textarea',
     '#title' => t('Opt-in statement'),
+    '#description' => t('This opt-in statement will be recorded as part of the supporter record in Campaignion, so that you have a clear history of what the supporter has signed up to and when. Make sure it matches the visible text in the form!'),
     '#default_value' => $component['extra']['optin_statement'],
     '#parents' => ['extra', 'optin_statement'],
   ];
 
   $optout_id = drupal_html_id('newsletter-no-is-optout');
-  $form['extra']['no_is_optout'] = [
+  $form['behavior']['no_is_optout'] = [
     '#type' => 'checkbox',
     '#title' => t('No (radio) is taken as opt-out'),
     '#default_value' => !empty($component['extra']['no_is_optout']),
     '#id' => $optout_id,
     '#parents' => ['extra', 'no_is_optout'],
+    '#states' => ['visible' => ["#$display_id" => ['value' => 'radios']]],
   ];
 
-  $form['extra']['optout_all_lists'] = [
+  $form['behavior']['optout_all_lists'] = [
     '#type' => 'checkbox',
-    '#title' => t('On opt-out: Remove all subscriptions for this email address.'),
+    '#title' => t('If the email address is unsubscribed it will be unsubscribed from all email lists.'),
     '#default_value' => !empty($component['extra']['optout_all_lists']),
-    '#states' => ['visible' => ["#$optout_id" => ['checked' => TRUE]]],
+    '#states' => ['visible' => [
+      "#$optout_id" => ['checked' => TRUE],
+      "#$display_id" => ['value' => 'radios'],
+    ]],
     '#parents' => ['extra', 'optout_all_lists'],
   ];
 

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -16,7 +16,7 @@ function _webform_defaults_newsletter() {
     'required' => 0,
     'pid' => 0,
     'weight' => 0,
-    'value' => serialize(array('subscribed' => 'subscribed')),
+    'value' => serialize(['']),
     'extra' => array(
       'items' => '',
       'multiple' => NULL,

--- a/campaignion_newsletters/campaignion_newsletters.conditionals.js
+++ b/campaignion_newsletters/campaignion_newsletters.conditionals.js
@@ -10,7 +10,7 @@
   Drupal.webform.conditionalOperatorNewsletterEqual = function (element, existingValue, ruleValue) {
     var checkbox = element.querySelector('.form-type-checkbox input');
     if (checkbox) {
-      return checkbox.checked ? ruleValue === 'yes' : ruleValue === 'no';
+      return checkbox.checked ? ruleValue === 'yes' : ruleValue === '';
     }
     var radio = element.querySelector('.form-type-radio input:checked');
     if (radio) {
@@ -18,7 +18,7 @@
       return element.querySelector('input:checked').value === ruleValue;
     }
     // If no radio is selected at the moment this counts as "no opt-in".
-    return ruleValue === 'no';
+    return ruleValue === '';
   };
   Drupal.webform.conditionalOperatorNewsletterNotEqual = function (element, existingValue, ruleValue) {
     return !Drupal.webform.conditionalOperatorNewsletterEqual(element, existingValue, ruleValue);

--- a/campaignion_newsletters/campaignion_newsletters.install
+++ b/campaignion_newsletters/campaignion_newsletters.install
@@ -187,15 +187,33 @@ function campaignion_newsletters_uninstall() {
 }
 
 /**
- * Update internal representation of conditional values ('no' → '').
+ * Migrate old newsletter conditional filters to new filters.
  */
 function campaignion_newsletters_update_16() {
   $sql = <<<SQL
 UPDATE webform_conditional_rules r
-  INNER JOIN webform_component c ON r.nid=c.nid AND r.source=c.cid SET r.value=''
-WHERE source_type='component' AND r.value='no'
+  INNER JOIN webform_component c ON r.nid=c.nid AND r.source=c.cid
+SET r.value=''
+WHERE source_type='component' AND c.type='newsletter' AND r.value IN ('no', 'No')
 SQL;
   db_query($sql);
+
+  $sql = <<<SQL
+UPDATE webform_conditional_rules r
+  INNER JOIN webform_component c ON r.nid=c.nid AND r.source=c.cid
+SET r.value='yes'
+WHERE source_type='component' AND c.type='newsletter' AND r.value IN ('yes', 'Yes', 'subscribed')
+SQL;
+  db_query($sql);
+
+  $sql = <<<SQL
+UPDATE webform_conditional_rules r
+  INNER JOIN webform_component c ON r.nid=c.nid AND r.source=c.cid
+SET r.operator='equal'
+WHERE source_type='component' AND c.type='newsletter' AND r.operator='empty'
+SQL;
+  db_query($sql);
+
 }
 
 /**

--- a/campaignion_newsletters/campaignion_newsletters.install
+++ b/campaignion_newsletters/campaignion_newsletters.install
@@ -187,6 +187,18 @@ function campaignion_newsletters_uninstall() {
 }
 
 /**
+ * Update internal representation of conditional values ('no' → '').
+ */
+function campaignion_newsletters_update_16() {
+  $sql = <<<SQL
+UPDATE webform_conditional_rules r
+  INNER JOIN webform_component c ON r.nid=c.nid AND r.source=c.cid SET r.value=''
+WHERE source_type='component' AND r.value='no'
+SQL;
+  db_query($sql);
+}
+
+/**
  * Add an updated and last_sync timestamps to newsletter subscriptions.
  */
 function campaignion_newsletters_update_15() {

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -7,6 +7,7 @@
 
 use Drupal\campaignion_newsletters\CronRunner;
 use Drupal\campaignion_newsletters\ProviderFactory;
+use Drupal\campaignion_newsletters\FormBuilderElementNewsletter;
 use Drupal\campaignion_newsletters\FormSubmission;
 use Drupal\campaignion_newsletters\NewsletterList;
 use Drupal\campaignion_newsletters\Subscription;
@@ -233,6 +234,7 @@ function campaignion_newsletters_form_builder_element_types($form_type, $form_id
   unset($map['properties']['description']);
   $fields['newsletter'] = array(
     'title' => t('Newsletter'),
+    'class' => FormBuilderElementNewsletter::class,
     'properties' => array_keys($map['properties']),
     'default' => array(
       '#form_builder' => array('element_type' => 'newsletter'),

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -5,12 +5,10 @@
  * Campaignion newsletter module.
  */
 
+use Drupal\campaignion_newsletters\Component;
 use Drupal\campaignion_newsletters\CronRunner;
 use Drupal\campaignion_newsletters\ProviderFactory;
 use Drupal\campaignion_newsletters\FormBuilderElementNewsletter;
-use Drupal\campaignion_newsletters\FormSubmission;
-use Drupal\campaignion_newsletters\NewsletterList;
-use Drupal\campaignion_newsletters\Subscription;
 use Drupal\campaignion_newsletters\Subscriptions;
 use Drupal\campaignion\CRM\Import\Source\WebformSubmission;
 use Drupal\little_helpers\Webform\Submission;
@@ -153,49 +151,13 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
     return;
   }
   foreach ($s->webform->componentsByType('newsletter') as $component) {
-    $value = $s->valueByCid($component['cid']);
-    if ($value == 'subscribed') {
-      $needs_opt_in = !$component['extra']['opt_in_implied'];
-      foreach ($component['extra']['lists'] as $list_id => $enabled) {
-        if (!empty($enabled)) {
-          $subscription = Subscription::byData($list_id, $email);
-          $subscription->delete = FALSE;
-          $subscription->source = $s;
-          $subscription->needs_opt_in = $needs_opt_in;
-          $subscription->send_welcome = (bool) $component['extra']['send_welcome'];
-          $subscription->optin_statement = $component['extra']['optin_statement'];
-          $subscription->optin_info = FormSubmission::fromWebformSubmission($s);
-          $subscription->save();
-        }
+    if ($value = $s->valueByCid($component['cid'])) {
+      $c = new Component($component);
+      if ($value == 'subscribed') {
+        $c->subscribe($email);
       }
-    }
-    elseif ($value == 'unsubscribed') {
-      $all_lists = $component['extra']['optout_all_lists'];
-      if ($all_lists) {
-        if (variable_get_value('campaignion_newsletters_opt_out_unknown')) {
-          foreach (NewsletterList::listAll() as $l) {
-            $subscription = Subscription::byData($l->list_id, $email);
-            if ($subscription->isNew()) {
-              $subscription->queueUnsubscribe();
-            }
-            else {
-              $subscription->delete();
-            }
-          }
-        }
-        else {
-          foreach (Subscription::byEmail($email) as $subscription) {
-            $subscription->delete();
-          }
-        }
-      }
-      else {
-        $lists = $component['extra']['lists'];
-        foreach (Subscription::byEmail($email) as $subscription) {
-          if (!empty($lists[$subscription->list_id])) {
-            $subscription->delete();
-          }
-        }
+      elseif ($value == 'unsubscribed') {
+        $c->unsubscribe($email);
       }
     }
   }

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -79,7 +79,6 @@ function campaignion_newsletters_webform_component_info() {
     'description' => t('Offers a user to subscribe to a given newsletter.'),
     'features' => [
       'conditional' => TRUE,
-      'description' => FALSE,
     ],
     'file' => 'campaignion_newsletters.component.inc',
     'conditional_type' => 'newsletter',
@@ -193,7 +192,6 @@ function campaignion_newsletters_form_builder_element_types($form_type, $form_id
   $map = _form_builder_webform_property_map('newsletter');
   // Default value is handled by the newsletter property.
   unset($map['properties']['default_value']);
-  unset($map['properties']['description']);
   $fields['newsletter'] = array(
     'title' => t('Newsletter'),
     'class' => FormBuilderElementNewsletter::class,

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -8,6 +8,7 @@
 use Drupal\campaignion_newsletters\CronRunner;
 use Drupal\campaignion_newsletters\ProviderFactory;
 use Drupal\campaignion_newsletters\FormSubmission;
+use Drupal\campaignion_newsletters\NewsletterList;
 use Drupal\campaignion_newsletters\Subscription;
 use Drupal\campaignion_newsletters\Subscriptions;
 use Drupal\campaignion\CRM\Import\Source\WebformSubmission;
@@ -117,7 +118,8 @@ function campaignion_newsletters_webform_conditional_form($node) {
         '#type' => 'select',
         '#options' => [
           'yes' => t('Opt-in'),
-          'no' => t('No opt-in'),
+          '' => t('No change'),
+          'no' => t('Opt-out'),
         ],
       ];
       $forms[$cid] = drupal_render($element);
@@ -167,8 +169,32 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
       }
     }
     elseif ($value == 'unsubscribed') {
-      foreach (Subscription::byEmail($email) as $subscription) {
-        $subscription->delete();
+      $all_lists = $component['extra']['optout_all_lists'];
+      if ($all_lists) {
+        if (variable_get_value('campaignion_newsletters_opt_out_unknown')) {
+          foreach (NewsletterList::listAll() as $l) {
+            $subscription = Subscription::byData($l->list_id, $email);
+            if ($subscription->isNew()) {
+              $subscription->queueUnsubscribe();
+            }
+            else {
+              $subscription->delete();
+            }
+          }
+        }
+        else {
+          foreach (Subscription::byEmail($email) as $subscription) {
+            $subscription->delete();
+          }
+        }
+      }
+      else {
+        $lists = $component['extra']['lists'];
+        foreach (Subscription::byEmail($email) as $subscription) {
+          if (!empty($lists[$subscription->list_id])) {
+            $subscription->delete();
+          }
+        }
       }
     }
   }

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -150,10 +150,11 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
     return;
   }
   foreach ($s->webform->componentsByType('newsletter') as $component) {
-    if ($s->valueByCid($component['cid'])) {
+    $value = $s->valueByCid($component['cid']);
+    if ($value == 'subscribed') {
       $needs_opt_in = !$component['extra']['opt_in_implied'];
-      foreach ($component['extra']['lists'] as $list_id => $value) {
-        if (!empty($value)) {
+      foreach ($component['extra']['lists'] as $list_id => $enabled) {
+        if (!empty($enabled)) {
           $subscription = Subscription::byData($list_id, $email);
           $subscription->delete = FALSE;
           $subscription->source = $s;
@@ -163,6 +164,11 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
           $subscription->optin_info = FormSubmission::fromWebformSubmission($s);
           $subscription->save();
         }
+      }
+    }
+    elseif ($value == 'unsubscribed') {
+      foreach (Subscription::byEmail($email) as $subscription) {
+        $subscription->delete();
       }
     }
   }

--- a/campaignion_newsletters/campaignion_newsletters.variable.inc
+++ b/campaignion_newsletters/campaignion_newsletters.variable.inc
@@ -23,5 +23,12 @@ function campaignion_newsletters_variable_info($options) {
     'default' => 5,
     'localize' => FALSE,
   ];
+  $v['campaignion_newsletters_unsubscribe_unknown'] = [
+    'title' => t('Try removing unknown subscriptions.', [], $options),
+    'description' => t('When unsubscribing from all lists try to unsubscribe from all lists instead of just those that we have subscriptions for.', [], $options),
+    'type' => 'boolean',
+    'default' => FALSE,
+    'localize' => FALSE,
+  ];
   return $v;
 }

--- a/campaignion_newsletters/src/Component.php
+++ b/campaignion_newsletters/src/Component.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Drupal\campaignion_newsletters;
+
+use Drupal\campaignion\CRM\Import\Source\WebformSubmission;
+use Drupal\little_helpers\ArrayConfig;
+
+/**
+ * Special functionality for the newsletter webform component.
+ */
+class Component {
+
+  /**
+   * The component array storing all configuration.
+   *
+   * @var array
+   */
+  protected $component;
+
+  /**
+   * Flag: Unsubscribe lists for which we don’t know of a subscription.
+   *
+   * @var bool
+   */
+  protected $unsubscribeUnknown;
+
+  /**
+   * All list_ids for this installation used for lazy-loading.
+   *
+   * @var int[]
+   */
+  protected $allListIds = NULL;
+
+  /**
+   * Get a new instance from a component array and reading the global config.
+   *
+   * @param array $component
+   *   Component array as stored in `$node->webform['components']`.
+   */
+  public static function fromComponent(array $component) {
+    $unsubscribe_unknown = variable_get_value('campaignion_newsletters_opt_out_unknown');
+    return new static($component, $unsubscribe_unknown);
+  }
+
+  /**
+   * Construct a new instance.
+   *
+   * @param array $component
+   *   Component array as stored in `$node->webform['components']`.
+   * @param bool $unsubscribe_unknown
+   *   Whether to try to unsubscribe even from lists without a subscription.
+   */
+  public function __construct(array $component, $unsubscribe_unknown) {
+    ArrayConfig::mergeDefaults($component, webform_component_invoke('newsletter', 'defaults'));
+    $this->component = $component;
+    $this->unsubscribeUnknown = $unsubscribe_unknown;
+  }
+
+  /**
+   * Unsubscribe the email address from configured/all newsletter lists.
+   *
+   * @param string $email
+   *   The email address to unsubscribe.
+   */
+  public function unsubscribe($email) {
+    $all_lists = !empty($this->component['extra']['optout_all_lists']);
+    if ($all_lists) {
+      if ($this->unsubscribeUnknown) {
+        foreach ($this->getAllListIds() as $list_id) {
+          $subscription = Subscription::byData($list_id, $email);
+          if ($subscription->isNew()) {
+            $subscription->queueUnsubscribe();
+          }
+        }
+      }
+      foreach (Subscription::byEmail($email) as $subscription) {
+        $subscription->delete();
+      }
+    }
+    else {
+      $lists = $this->component['extra']['lists'];
+      foreach (Subscription::byEmail($email) as $subscription) {
+        if (!empty($lists[$subscription->list_id])) {
+          $subscription->delete();
+        }
+      }
+    }
+  }
+
+  /**
+   * Subscribe an email address to all configured lists.
+   *
+   * @param string $email
+   *   The email address to subscribe.
+   * @param \Drupal\campaignion\CRM\Import\Source\WebformSubmission $source
+   *   The importer source for further CRM action.
+   */
+  public function subscribe($email, WebformSubmission $source) {
+    $extra = $this->component['extra'];
+    $lists = array_keys(array_filter($extra['lists']));
+    foreach ($lists as $list_id) {
+      $subscription = Subscription::byData($list_id, $email, [
+        'source' => $source,
+        'needs_opt_in' => !$extra['opt_in_implied'],
+        'send_welcome' => (bool) $extra['send_welcome'],
+        'optin_statement' => $extra['optin_statement'],
+        'optin_info' => FormSubmission::fromWebformSubmission($source),
+      ]);
+      $subscription->save();
+    }
+  }
+
+  /**
+   * Set the array of all list IDs. Usually only used for testing.
+   *
+   * @param int[]
+   *   Array of list IDs.
+   */
+  public function setAllListIds(array $list_ids) {
+    $this->allListIds = $list_ids;
+  }
+
+  /**
+   * Get all list IDs.
+   *
+   * @return int[]
+   *   Array of list IDs.
+   */
+  public function getAllListIds() {
+    if (is_null($this->allListIds)) {
+      $list_ids = [];
+      foreach (NewsletterList::listAll() as $l) {
+        $list_ids[] = $l;
+      }
+      $this->setAllListIds($list_ids);
+    }
+    return $this->allListIds;
+  }
+
+}

--- a/campaignion_newsletters/src/FormBuilderElementNewsletter.php
+++ b/campaignion_newsletters/src/FormBuilderElementNewsletter.php
@@ -37,26 +37,4 @@ class FormBuilderElementNewsletter extends \FormBuilderWebformElement {
     return $form;
   }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function configurationSubmit(&$form, &$form_state) {
-    $form_state['values']['newsletter_lists'] = $form_state['values']['options']['lists'];
-    parent::configurationSubmit($form, $form_state);
-
-    $component = &$this->element['#webform_component'];
-    $values = $form_state['values'];
-    $component['extra']['lists'] = $values['options']['lists'];
-    $component['value'] = $values['value'];
-    $component['extra']['description'] = $values['title'];
-    $component['extra']['opt_in_implied'] = $values['opt_in_implied'];
-    $component['extra']['send_welcome'] = $values['send_welcome'];
-    $component['extra']['display'] = $values['display'];
-    $component['extra']['radio_labels'] = $values['radio_labels'];
-    $component['extra']['checkbox_label'] = $values['checkbox_label'];
-    $component['extra']['optin_statement'] = $values['optin_statement'];
-    $component['extra']['no_is_optout'] = $values['no_is_optout'];
-    $component['extra']['optout_all_lists'] = $values['optout_all_lists'];
-  }
-
 }

--- a/campaignion_newsletters/src/FormBuilderElementNewsletter.php
+++ b/campaignion_newsletters/src/FormBuilderElementNewsletter.php
@@ -15,25 +15,26 @@ class FormBuilderElementNewsletter extends \FormBuilderWebformElement {
 
     $component = $this->element['#webform_component'];
 
-    // In order for the groups to work we need a flattened array of elements.
+    $form['#property_groups']['lists'] = [
+      'title' => t('Lists'),
+      'weight' => 2,
+    ];
+
+    // Only top-level elements can be assigned to property groups.
     // @see form_builder_field_configure_pre_render()
     $edit = _webform_edit_newsletter($component);
-    $form['options'] = array(
-      '#form_builder' => array('property_group' => 'options'),
-      '#tree' => TRUE,
-    );
-    $form['options']['lists'] = $edit['extra']['lists'];
-    $form['value'] = $edit['value'];
+    $form['lists'] = ['#type' => NULL] + $edit['list_management'];
+    $form['lists']['#form_builder']['property_group'] = 'lists';
+    $form['value'] = $edit['behavior']['value'];
     $form['description'] = $edit['extra']['description'];
-    $form['opt_in_implied'] = $edit['extra']['opt_in_implied'];
-    $form['send_welcome'] = $edit['extra']['send_welcome'];
     $dp['#form_builder']['property_group'] = 'display';
     $form['display'] = $edit['extra']['display'] + $dp;
     $form['checkbox_label'] = $edit['extra']['checkbox_label'] + $dp;
     $form['radio_labels'] = $edit['extra']['radio_labels'] + $dp;
     $form['optin_statement'] = $edit['extra']['optin_statement'];
-    $form['no_is_optout'] = $edit['extra']['no_is_optout'];
-    $form['optout_all_lists'] = $edit['extra']['optout_all_lists'];
+    $form['no_is_optout'] = $edit['behavior']['no_is_optout'];
+    $form['optout_all_lists'] = $edit['behavior']['optout_all_lists'];
+
     return $form;
   }
 

--- a/campaignion_newsletters/src/FormBuilderElementNewsletter.php
+++ b/campaignion_newsletters/src/FormBuilderElementNewsletter.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\campaignion_newsletters;
+
+/**
+ * Form builder integration for the newsletter webform component.
+ */
+class FormBuilderElementNewsletter extends \FormBuilderWebformElement {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function configurationForm($form, &$form_state) {
+    $form = parent::configurationForm($form, $form_state);
+
+    $component = $this->element['#webform_component'];
+
+    // In order for the groups to work we need a flattened array of elements.
+    // @see form_builder_field_configure_pre_render()
+    $edit = _webform_edit_newsletter($component);
+    $form['options'] = array(
+      '#form_builder' => array('property_group' => 'options'),
+      '#tree' => TRUE,
+    );
+    $form['options']['lists'] = $edit['extra']['lists'];
+    $form['value'] = $edit['value'];
+    $form['description'] = $edit['extra']['description'];
+    $form['opt_in_implied'] = $edit['extra']['opt_in_implied'];
+    $form['send_welcome'] = $edit['extra']['send_welcome'];
+    $dp['#form_builder']['property_group'] = 'display';
+    $form['display'] = $edit['extra']['display'] + $dp;
+    $form['checkbox_label'] = $edit['extra']['checkbox_label'] + $dp;
+    $form['radio_labels'] = $edit['extra']['radio_labels'] + $dp;
+    $form['optin_statement'] = $edit['extra']['optin_statement'];
+    $form['no_is_optout'] = $edit['extra']['no_is_optout'];
+    $form['optout_all_lists'] = $edit['extra']['optout_all_lists'];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function configurationSubmit(&$form, &$form_state) {
+    $form_state['values']['newsletter_lists'] = $form_state['values']['options']['lists'];
+    parent::configurationSubmit($form, $form_state);
+
+    $component = &$this->element['#webform_component'];
+    $values = $form_state['values'];
+    $component['extra']['lists'] = $values['options']['lists'];
+    $component['value'] = $values['value'];
+    $component['extra']['description'] = $values['title'];
+    $component['extra']['opt_in_implied'] = $values['opt_in_implied'];
+    $component['extra']['send_welcome'] = $values['send_welcome'];
+    $component['extra']['display'] = $values['display'];
+    $component['extra']['radio_labels'] = $values['radio_labels'];
+    $component['extra']['checkbox_label'] = $values['checkbox_label'];
+    $component['extra']['optin_statement'] = $values['optin_statement'];
+    $component['extra']['no_is_optout'] = $values['no_is_optout'];
+    $component['extra']['optout_all_lists'] = $values['optout_all_lists'];
+  }
+
+}

--- a/campaignion_newsletters/src/FormBuilderElementNewsletter.php
+++ b/campaignion_newsletters/src/FormBuilderElementNewsletter.php
@@ -12,6 +12,7 @@ class FormBuilderElementNewsletter extends \FormBuilderWebformElement {
    */
   public function configurationForm($form, &$form_state) {
     $form = parent::configurationForm($form, $form_state);
+    $form['description']['#weight'] = 0;
 
     $component = $this->element['#webform_component'];
 
@@ -26,7 +27,6 @@ class FormBuilderElementNewsletter extends \FormBuilderWebformElement {
     $form['lists'] = ['#type' => NULL] + $edit['list_management'];
     $form['lists']['#form_builder']['property_group'] = 'lists';
     $form['value'] = $edit['behavior']['value'];
-    $form['description'] = $edit['extra']['description'];
     $dp['#form_builder']['property_group'] = 'display';
     $form['display'] = $edit['extra']['display'] + $dp;
     $form['checkbox_label'] = $edit['extra']['checkbox_label'] + $dp;

--- a/campaignion_newsletters/src/Subscription.php
+++ b/campaignion_newsletters/src/Subscription.php
@@ -35,18 +35,20 @@ class Subscription extends Model {
    *   A list id.
    * @param string $email
    *   An email address.
+   * @param array $data
+   *   Additional data to pass to the constructor.
    */
-  public static function byData($list_id, $email) {
+  public static function byData($list_id, $email, array $data = []) {
     $result = db_select(static::$table, 's')
       ->fields('s')
       ->condition('list_id', $list_id)
       ->condition('email', $email)
       ->execute();
-    if ($row = $result->fetch()) {
-      return new static($row, FALSE);
+    if ($row = $result->fetchAssoc()) {
+      return new static($row + $data, FALSE);
     }
     else {
-      return static::fromData($list_id, $email);
+      return static::fromData($list_id, $email, $data);
     }
   }
 
@@ -57,12 +59,14 @@ class Subscription extends Model {
    *   A list id.
    * @param string $email
    *   An email address.
+   * @param array $data
+   *   Additional data to pass to the constructor.
    */
-  public static function fromData($list_id, $email) {
+  public static function fromData($list_id, $email, array $data = []) {
     return new static(array(
       'list_id' => $list_id,
       'email' => $email,
-    ), TRUE);
+    ) + $data, TRUE);
   }
 
   /**

--- a/campaignion_newsletters/src/Subscription.php
+++ b/campaignion_newsletters/src/Subscription.php
@@ -175,14 +175,21 @@ class Subscription extends Model {
       return;
     }
     if (!$from_provider) {
-      QueueItem::byData(array(
-        'list_id' => $this->list_id,
-        'email' => $this->email,
-        'action' => QueueItem::UNSUBSCRIBE,
-      ))->save();
+      $this->queueUnsubscribe();
     }
     parent::delete();
     module_invoke_all('campaignion_newsletters_subscription_deleted', $this, $from_provider);
+  }
+
+  /**
+   * Queue an unsubscribe request for this subscription.
+   */
+  public function queueUnsubscribe() {
+    QueueItem::byData(array(
+      'list_id' => $this->list_id,
+      'email' => $this->email,
+      'action' => QueueItem::UNSUBSCRIBE,
+    ))->save();
   }
 
 }

--- a/campaignion_newsletters/src/Subscriptions.php
+++ b/campaignion_newsletters/src/Subscriptions.php
@@ -2,12 +2,32 @@
 
 namespace Drupal\campaignion_newsletters;
 
+/**
+ * Manage a matrix of subscriptions statuses.
+ */
 class Subscriptions {
+
+  /**
+   * Subscriptions keyed by email and list ID.
+   *
+   * @var \Drupal\campaignion_newsletters\Subscription[][]
+   */
   protected $subscriptions;
 
+  /**
+   * Static cache for all newsletter lists.
+   *
+   * @var \Drupal\campaignion_newsletters\NewsletterList[]
+   */
   protected static $lists = NULL;
 
-  public static function byContact($contact) {
+  /**
+   * Generate a new subscription matrix for a contact.
+   *
+   * @param \RedhenContact $contact
+   *   The redhen contact to generate the matrix for.
+   */
+  public static function byContact(\RedhenContact $contact) {
     $lists = static::lists();
     $addresses = array();
     foreach ($contact->allEmail() as $address) {
@@ -17,7 +37,17 @@ class Subscriptions {
     return new static($lists, $addresses, $storedSubscriptions);
   }
 
-  public function __construct($lists, $addresses, $storedSubscriptions) {
+  /**
+   * Construct a new subscription matrix.
+   *
+   * @param \Drupal\campaignion_newsletters\NewsletterList[] $lists
+   *   Array of all available newsletter lists.
+   * @param string[] $addresses
+   *   Array of email addresses that may be subscribed.
+   * @param \Drupal\campaignion_newsletters\Subscription[] $stored_subscriptions
+   *   Existing subscriptions.
+   */
+  public function __construct(array $lists, array $addresses, array $stored_subscriptions) {
     $subscriptions = array();
     foreach ($addresses as $email) {
       $subscriptions[$email] = array();
@@ -26,12 +56,18 @@ class Subscriptions {
       }
     }
 
-    foreach ($storedSubscriptions as $s) {
+    foreach ($stored_subscriptions as $s) {
       $subscriptions[$s->email][$s->list_id] = $s;
     }
     $this->subscriptions = $subscriptions;
   }
 
+  /**
+   * Get an array of all newsletter lists.
+   *
+   * @return \Drupal\campaignion_newsletters\NewsletterList[]
+   *   All currently known newsletter lists.
+   */
   public static function lists() {
     if (!isset(static::$lists)) {
       static::$lists = NewsletterList::listAll();
@@ -39,7 +75,15 @@ class Subscriptions {
     return static::$lists;
   }
 
-  public function update($values) {
+  /**
+   * Update the subscription matrix using a matrix of booleans.
+   *
+   * @param bool[][] $values
+   *   New subscription statuses keyed by email and list ID:
+   *   - TRUE for an active or new subscription.
+   *   - FALSE for no subscription or for deleting the subscription.
+   */
+  public function update(array $values) {
     foreach ($values as $email => $lists) {
       foreach ($lists as $list_id => $subscribed) {
         if ($subscription = &$this->subscriptions[$email][$list_id]) {
@@ -52,6 +96,9 @@ class Subscriptions {
     }
   }
 
+  /**
+   * Make all changes to the matrix persistent.
+   */
   public function save() {
     foreach ($this->subscriptions as $email => $lists) {
       foreach ($lists as $list_id => $subscription) {
@@ -62,6 +109,9 @@ class Subscriptions {
     }
   }
 
+  /**
+   * Remove all subscriptions.
+   */
   public function unsubscribeAll() {
     foreach ($this->subscriptions as $email => $lists) {
       foreach ($lists as $list_id => $subscription) {
@@ -72,6 +122,12 @@ class Subscriptions {
     }
   }
 
+  /**
+   * Generate an options array suitable for the form-API #options parameter.
+   *
+   * @return string[]
+   *   List titles keyed by list_id.
+   */
   public function optionsArray() {
     $options = array();
     foreach (static::lists() as $list_id => $list) {
@@ -80,6 +136,15 @@ class Subscriptions {
     return $options;
   }
 
+  /**
+   * Generate a values array suitable for the form-API #default_value.
+   *
+   * @param string $email
+   *   The email address for which to generate the options array.
+   *
+   * @return bool[]
+   *   Subscription status keyed by list_id.
+   */
   public function values($email) {
     $values = array();
     foreach ($this->subscriptions[$email] as $list_id => $subscription) {
@@ -87,4 +152,5 @@ class Subscriptions {
     }
     return $values;
   }
+
 }

--- a/campaignion_newsletters/tests/ComponentTest.php
+++ b/campaignion_newsletters/tests/ComponentTest.php
@@ -58,22 +58,24 @@ class ComponentTest extends \DrupalUnitTestCase {
     $export = function ($v) {
       return _webform_table_newsletter(NULL, $v);
     };
-    $this->assertEqual(t('not subscribed'), $export(NULL));
-    $this->assertEqual(t('not subscribed'), $export(['0']));
+    $this->assertEqual(t('no change'), $export(NULL));
+    $this->assertEqual(t('no change'), $export(['0']));
     $this->assertEqual(t('subscribed'), $export(['subscribed']));
     // Old format - backwards compatibility.
     $this->assertEqual(t('subscribed'), $export(['subscribed' => 'subscribed']));
+    $this->assertEqual(t('unsubscribed'), $export(['unsubscribed']));
   }
 
   public function testCsvData() {
     $export = function ($v) {
       return _webform_csv_data_newsletter(NULL, [], $v);
     };
-    $this->assertEqual(t('not subscribed'), $export(NULL));
-    $this->assertEqual(t('not subscribed'), $export(['0']));
+    $this->assertEqual(t('no change'), $export(NULL));
+    $this->assertEqual(t('no change'), $export(['0']));
     $this->assertEqual(t('subscribed'), $export(['subscribed']));
     // Old format - backwards compatibility.
     $this->assertEqual(t('subscribed'), $export(['subscribed' => 'subscribed']));
+    $this->assertEqual(t('unsubscribed'), $export(['unsubscribed']));
   }
 
 }

--- a/campaignion_newsletters/tests/ComponentTest.php
+++ b/campaignion_newsletters/tests/ComponentTest.php
@@ -41,13 +41,17 @@ class ComponentTest extends \DrupalUnitTestCase {
   public function testSubmitRadios() {
     $c['extra']['display'] = 'radios';
 
-    // Not checked checkbox.
+    // Radio no.
     $v = 'no';
-    $this->assertEqual([''], _webform_submit_newsletter($c, $v));
+    $this->assertEqual(['unsubscribed'], _webform_submit_newsletter($c, $v));
 
-    // Checked checkbox.
+    // Radio yes.
     $v = 'yes';
     $this->assertEqual(['subscribed'], _webform_submit_newsletter($c, $v));
+
+    // Not selected radio.
+    $v = NULL;
+    $this->assertEqual([''], _webform_submit_newsletter($c, $v));
   }
 
   public function testTable() {

--- a/campaignion_newsletters/tests/ConditionalTest.php
+++ b/campaignion_newsletters/tests/ConditionalTest.php
@@ -21,19 +21,37 @@ class ConditionalTest extends \DrupalUnitTestCase {
     $eq = '_webform_conditional_comparison_newsletter_equal';
     $ne = '_webform_conditional_comparison_newsletter_not_equal';
 
+    // Possible input values:
+    // - ['yes']: Yes radio is selected.
+    // - ['no']: No radio is selected and no_is_optout is set.
+    // - ['']: No radio is selected and no_is_optout is not set.
+    // - []: No radio is selected.
+    // Input value, rule value, component.
     $this->assertTrue($eq(['yes'], 'yes', []));
     $this->assertFalse($eq(['yes'], 'no', []));
+    $this->assertFalse($eq(['yes'], '', []));
     $this->assertFalse($eq(['no'], 'yes', []));
     $this->assertTrue($eq(['no'], 'no', []));
+    $this->assertFalse($eq(['no'], '', []));
+    $this->assertFalse($eq([''], 'yes', []));
+    $this->assertFalse($eq([''], 'no', []));
+    $this->assertTrue($eq([''], '', []));
     $this->assertFalse($eq([], 'yes', []));
-    $this->assertTrue($eq([], 'no', []));
+    $this->assertFalse($eq([], 'no', []));
+    $this->assertTrue($eq([], '', []));
 
     $this->assertFalse($ne(['yes'], 'yes', []));
     $this->assertTrue($ne(['yes'], 'no', []));
+    $this->assertTrue($ne(['yes'], '', []));
     $this->assertTrue($ne(['no'], 'yes', []));
     $this->assertFalse($ne(['no'], 'no', []));
+    $this->assertTrue($ne(['no'], '', []));
+    $this->assertTrue($ne([''], 'yes', []));
+    $this->assertTrue($ne([''], 'no', []));
+    $this->assertFalse($ne([''], '', []));
     $this->assertTrue($ne([], 'yes', []));
-    $this->assertFalse($ne([], 'no', []));
+    $this->assertTrue($ne([], 'no', []));
+    $this->assertFalse($ne([], '', []));
   }
 
   /**
@@ -45,13 +63,17 @@ class ConditionalTest extends \DrupalUnitTestCase {
 
     $this->assertTrue($eq(['subscribed' => 'subscribed'], 'yes', []));
     $this->assertFalse($eq(['subscribed' => 'subscribed'], 'no', []));
+    $this->assertFalse($eq(['subscribed' => 'subscribed'], '', []));
     $this->assertFalse($eq(['subscribed' => 0], 'yes', []));
-    $this->assertTrue($eq(['subscribed' => 0], 'no', []));
+    $this->assertFalse($eq(['subscribed' => 0], 'no', []));
+    $this->assertTrue($eq(['subscribed' => 0], '', []));
 
     $this->assertFalse($ne(['subscribed' => 'subscribed'], 'yes', []));
     $this->assertTrue($ne(['subscribed' => 'subscribed'], 'no', []));
+    $this->assertTrue($ne(['subscribed' => 'subscribed'], '', []));
     $this->assertTrue($ne(['subscribed' => 0], 'yes', []));
-    $this->assertFalse($ne(['subscribed' => 0], 'no', []));
+    $this->assertTrue($ne(['subscribed' => 0], 'no', []));
+    $this->assertFalse($ne(['subscribed' => 0], '', []));
   }
 
   /**
@@ -63,13 +85,23 @@ class ConditionalTest extends \DrupalUnitTestCase {
 
     $this->assertTrue($eq(['subscribed'], 'yes', []));
     $this->assertFalse($eq(['subscribed'], 'no', []));
+    $this->assertFalse($eq(['subscribed'], '', []));
+    $this->assertFalse($eq(['unsubscribed'], 'yes', []));
+    $this->assertTrue($eq(['unsubscribed'], 'no', []));
+    $this->assertFalse($eq(['unsubscribed'], '', []));
     $this->assertFalse($eq([''], 'yes', []));
-    $this->assertTrue($eq([''], 'no', []));
+    $this->assertFalse($eq([''], 'no', []));
+    $this->assertTrue($eq([''], '', []));
 
     $this->assertFalse($ne(['subscribed'], 'yes', []));
     $this->assertTrue($ne(['subscribed'], 'no', []));
+    $this->assertTrue($ne(['subscribed'], '', []));
+    $this->assertTrue($ne(['unsubscribed'], 'yes', []));
+    $this->assertFalse($ne(['unsubscribed'], 'no', []));
+    $this->assertTrue($ne(['unsubscribed'], '', []));
     $this->assertTrue($ne([''], 'yes', []));
-    $this->assertFalse($ne([''], 'no', []));
+    $this->assertTrue($ne([''], 'no', []));
+    $this->assertFalse($ne([''], '', []));
   }
 
 }

--- a/campaignion_newsletters/tests/SubscriptionsTest.php
+++ b/campaignion_newsletters/tests/SubscriptionsTest.php
@@ -2,7 +2,14 @@
 
 namespace Drupal\campaignion_newsletters;
 
+/**
+ * Test the subscriptions matrix.
+ */
 class SubscriptionsTest extends \DrupalWebTestCase {
+
+  /**
+   * Test storing new subscriptions.
+   */
   public function testSubscribeNew() {
     $list_stubs = array(4711 => NULL, 4712 => NULL);
     $addresses = array('test1@example.com', 'test2@example.com');
@@ -21,4 +28,5 @@ class SubscriptionsTest extends \DrupalWebTestCase {
     $this->assertEquals(1, count($s2));
     $this->assertEquals(4712, $s2[0]->list_id);
   }
+
 }

--- a/campaignion_newsletters/tests/WebformComponentTest.php
+++ b/campaignion_newsletters/tests/WebformComponentTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\campaignion_newsletters;
+
+/**
+ * Test the component behaviour.
+ *
+ * This includes test for the component callbacks defined in
+ * campaignion_newsletter.component.inc.
+ */
+class WebformComponentTest extends \DrupalUnitTestCase {
+
+  /**
+   * Load the components include file.
+   */
+  public function setUp() {
+    require_once drupal_get_path('module', 'campaignion_newsletters') . '/campaignion_newsletters.component.inc';
+  }
+
+  /**
+   * Test whether rendering the edit form with the default configuration works.
+   */
+  public function testComponentDefaults() {
+    $defaults = webform_component_invoke('newsletter', 'defaults');
+
+    $expected_subset = array(
+      'extra' => array(
+        'opt_in_implied' => 1,
+        'send_welcome' => 0,
+        'optin_statement' => '',
+      ),
+    );
+    $this->assertArraySubset($expected_subset, $defaults);
+
+    $component = webform_component_invoke('newsletter', 'edit', $defaults);
+    $this->assertEqual('textarea', $component['extra']['optin_statement']['#type']);
+  }
+
+  /**
+   * Test normalizing input values from a checkbox.
+   */
+  public function testSubmitCheckbox() {
+    $c['extra']['display'] = 'checkbox';
+
+    // Not checked checkbox.
+    $v['subscribed'] = 0;
+    $this->assertEqual([''], _webform_submit_newsletter($c, $v));
+
+    // Checked checkbox.
+    $v['subscribed'] = 'subscribed';
+    $this->assertEqual(['subscribed'], _webform_submit_newsletter($c, $v));
+  }
+
+  /**
+   * Test normalizing input values from radios.
+   */
+  public function testSubmitRadios() {
+    $c['extra']['display'] = 'radios';
+
+    // Radio no.
+    $v = 'no';
+    $this->assertEqual(['unsubscribed'], _webform_submit_newsletter($c, $v));
+
+    // Radio yes.
+    $v = 'yes';
+    $this->assertEqual(['subscribed'], _webform_submit_newsletter($c, $v));
+
+    // Not selected radio.
+    $v = NULL;
+    $this->assertEqual([''], _webform_submit_newsletter($c, $v));
+  }
+
+  /**
+   * Test rendering data for the table display.
+   */
+  public function testTable() {
+    $export = function ($v) {
+      return _webform_table_newsletter(NULL, $v);
+    };
+    $this->assertEqual(t('no change'), $export(NULL));
+    $this->assertEqual(t('no change'), $export(['0']));
+    $this->assertEqual(t('subscribed'), $export(['subscribed']));
+    // Old format - backwards compatibility.
+    $this->assertEqual(t('subscribed'), $export(['subscribed' => 'subscribed']));
+    $this->assertEqual(t('unsubscribed'), $export(['unsubscribed']));
+  }
+
+  /**
+   * Test rendering data for CSV output.
+   */
+  public function testCsvData() {
+    $export = function ($v) {
+      return _webform_csv_data_newsletter(NULL, [], $v);
+    };
+    $this->assertEqual(t('no change'), $export(NULL));
+    $this->assertEqual(t('no change'), $export(['0']));
+    $this->assertEqual(t('subscribed'), $export(['subscribed']));
+    // Old format - backwards compatibility.
+    $this->assertEqual(t('subscribed'), $export(['subscribed' => 'subscribed']));
+    $this->assertEqual(t('unsubscribed'), $export(['unsubscribed']));
+  }
+
+}


### PR DESCRIPTION
Reopens #77 that was accidentally merged.
    
* Changes how values are stored:
  * 'subscribed': checkbox checked OR radio yes [unchanged]
  * 'unsubscribed': radio no [NEW]
  * '': checkbox not checked OR radio not selected [unchanged]
* When the value is 'unsubscribed' the email address is unsubscribed from all known lists.
    
This will be made configurable in the future, but it’s enough for some  special cases for the while.

---

Configurability has now been added.