### PR TITLE
Check if user has 'update' permission for nodes

### DIFF
--- a/campaignion_manage/src/BulkOp/ContentPublish.php
+++ b/campaignion_manage/src/BulkOp/ContentPublish.php
@@ -19,12 +19,21 @@ STR;
     $element['warn']['message']['#markup'] = t($message, array('!count' => '<span class="bulkop-count"></span>'));
   }
   public function apply($nids, $values) {
+    $messages = [];
     $nodes = node_load_multiple($nids);
+
     foreach ($nodes as $node) {
       if (!$node->status) {
-        node_publish_action($node);
-        node_save($node);
+        if (node_access('update', $node)) {
+          node_publish_action($node);
+          node_save($node);
+        }
+        else {
+          array_push($messages, t("Could not publish '!node' due to lacking permissions.", ['!node' => $node->title]));
+        }
       }
     }
+
+    return $messages;
   }
 }

--- a/campaignion_manage/src/BulkOp/ContentUnpublish.php
+++ b/campaignion_manage/src/BulkOp/ContentUnpublish.php
@@ -21,12 +21,21 @@ STR;
     $element['warn']['message']['#markup'] = t($message, array('!count' => '<span class="bulkop-count"></span>'));
   }
   public function apply($nids, $values) {
+    $messages = [];
     $nodes = node_load_multiple($nids);
+
     foreach ($nodes as $node) {
       if ($node->status) {
-        node_unpublish_action($node);
-        node_save($node);
+        if (node_access('update', $node)) {
+          node_unpublish_action($node);
+          node_save($node);
+        }
+        else {
+          array_push($messages, t("Could not unpublish '!node' due to lacking permissions.", ['!node' => $node->title]));
+        }
       }
     }
+
+    return $messages;
   }
 }

--- a/campaignion_manage/src/BulkOpForm.php
+++ b/campaignion_manage/src/BulkOpForm.php
@@ -65,6 +65,12 @@ class BulkOpForm {
     }
     $op = $this->ops[$op_name];
     $op_parameters = isset($values['op-wrapper']['op'][$op_name]) ? $values['op-wrapper']['op'][$op_name] : NULL;
-    $op->apply($result, $op_parameters);
+    $messages = $op->apply($result, $op_parameters);
+
+    if (is_array($messages)) {
+      foreach ($messages as $msg) {
+        drupal_set_message($msg, 'error');
+      }
+    }
   }
 }

--- a/campaignion_manage/src/ContentListing.php
+++ b/campaignion_manage/src/ContentListing.php
@@ -127,11 +127,14 @@ class ContentListing {
       }
     }
     foreach (array($edit_path_part => t('Edit'), 'translate' => t('Translate'), 'view' => t('View page'), 'delete' => t('Delete')) as $path => $title) {
-      $links[$path] = array(
-        'href' => "node/{$node->nid}/$path",
-        'title' => $title,
-        'query' => array('destination' => 'admin/manage/content_and_actions')
-      );
+      $action = in_array($path, ['wizard', 'edit']) ? 'update' : $path;
+      if (node_access($action, $node)) {
+        $links[$path] = array(
+          'href' => "node/{$node->nid}/$path",
+          'title' => $title,
+          'query' => array('destination' => 'admin/manage/content_and_actions')
+        );
+      }
     }
     return $links;
   }

--- a/campaignion_manage/tests/UnPublishTest.php
+++ b/campaignion_manage/tests/UnPublishTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\campaignion_manage;
+
+use Drupal\campaignion_manage\BulkOp\ContentPublish;
+use Drupal\campaignion_manage\BulkOp\ContentUnpublish;
+
+/**
+ * Contains tests for the ContentPublish and ContentUnpublish classes.
+ */
+class UnPublishTest extends \DrupalUnitTestCase {
+  protected $draftNode = NULL;
+  protected $publicNode = NULL;
+
+  /**
+   * Prepares a `Campaign` node for testing.
+   */
+  public function setUp() {
+    parent::setUp(['campaignion_test']);
+
+    $draft_campaign = (object) [
+      'title' => 'Testcampaign',
+      'type' => 'campaign',
+      'status' => 0,
+    ];
+    node_save($draft_campaign);
+    $this->draftNode = $draft_campaign;
+
+    $public_campaign = (object) [
+      'title' => 'A campaign',
+      'type' => 'campaign',
+      'status' => 1,
+    ];
+    node_save($public_campaign);
+    $this->publicNode = $public_campaign;
+  }
+
+  /**
+   * Checks if anonymous users are disallowed from (un)publishing.
+   */
+  public function testAnonymousUser() {
+    $publish_job = new ContentPublish();
+    $unpublish_job = new ContentUnpublish();
+
+    // Check that publishing the draft node fails.
+    $msgs = $publish_job->apply([$this->draftNode->nid], []);
+    $this->assertNotEmpty($msgs);
+
+    // Check that 'unpublishing' the draft node results in no
+    // errors.
+    $msgs = $unpublish_job->apply([$this->draftNode->nid], []);
+    $this->assertEmpty($msgs);
+
+    // Check that unpublishing a public node fails.
+    $msgs = $unpublish_job->apply([$this->publicNode->nid], []);
+    $this->assertNotEmpty($msgs);
+
+    // Check that 'publishing' a public node results in no errors.
+    $msgs = $publish_job->apply([$this->publicNode->nid], []);
+    $this->assertEmpty($msgs);
+  }
+
+  /**
+   * Deletes the test `Campaign` node.
+   */
+  public function tearDown() {
+    node_delete($this->draftNode->nid);
+    node_delete($this->publicNode->nid);
+  }
+
+}


### PR DESCRIPTION
Prevents users from circumventing access controls for (un)publishing nodes via batch jobs.