### PR TITLE
add opt-in statement to newsletter subscription

### DIFF
--- a/campaignion_activity/campaignion_activity.install
+++ b/campaignion_activity/campaignion_activity.install
@@ -161,6 +161,11 @@ function campaignion_activity_schema() {
       'from_provider' => [
         'description' => 'Flag for whether the change was initiated by the provider',
       ] + $unsigned_int_not_null,
+      'optin_statement' => [
+        'description' => 'Opt-in statement',
+        'type' => 'text',
+        'not null' => FALSE,
+      ],
     ],
     'primary key' => ['activity_id'],
     'indexes' => [
@@ -187,6 +192,17 @@ function campaignion_activity_schema() {
  */
 function campaignion_activity_uninstall() {
   variable_del('campaignion_activity_log_contact_save');
+}
+
+/**
+ * Add opt-in statement to newsletter subscription activities.
+ */
+function campaignion_activity_update_6() {
+  db_add_field('campaignion_activity_newsletter_subscription', 'optin_statement', array(
+    'description' => 'Opt-in statement',
+    'type' => 'text',
+    'not null' => FALSE,
+  ));
 }
 
 /**

--- a/campaignion_activity/campaignion_activity.install
+++ b/campaignion_activity/campaignion_activity.install
@@ -1,6 +1,16 @@
 <?php
 
-function campaignion_activity_schema() { 
+/**
+ * @file
+ * Schema definitions and migration functions.
+ */
+
+use Drupal\campaignion_activity\WebformSubmission;
+
+/**
+ * Implements hook_schema().
+ */
+function campaignion_activity_schema() {
   $unsigned_int_not_null = array(
     'type' => 'int',
     'not null' => TRUE,
@@ -281,7 +291,7 @@ function campaignion_activity_update_2() {
   $sql = "SELECT activity_id FROM {campaignion_activity_webform} a INNER JOIN {campaignion_activity} ca USING(activity_id) INNER JOIN {webform_submissions} w USING(nid,sid) WHERE a.confirmed IS NULL AND w.confirmed=1 AND created>=1406851200 LIMIT 1000";
   while ($ids = db_query($sql)->fetchCol()) {
     foreach ($ids as $id) {
-      if ($activity = \Drupal\campaignion_activity\WebformSubmission::load($id)) {
+      if ($activity = WebformSubmission::load($id)) {
         $activity->confirmed = time();
         $activity->save();
       }
@@ -296,8 +306,12 @@ function campaignion_activity_update_1() {
   if (!module_exists('message')) {
     return;
   }
+  /**
+   * Ad-hoc EntityAPIController without cache.
+   */
   class NoCacheEntityController extends EntityAPIController {
     protected $cache = FALSE;
+
   }
 
   $sql = <<<SQL
@@ -319,9 +333,19 @@ SQL;
     $mids = db_query($sql)->fetchCol();
     drupal_static_reset();
   }
-  
-  module_disable(array('ae_engagement_scores', 'redhen_activity', 'redhen_engagement', 'message'));
-  drupal_uninstall_modules(array('ae_engagement_scores', 'redhen_activity', 'redhen_engagement', 'message'));
+
+  module_disable(array(
+    'ae_engagement_scores',
+    'redhen_activity',
+    'redhen_engagement',
+    'message',
+  ));
+  drupal_uninstall_modules(array(
+    'ae_engagement_scores',
+    'redhen_activity',
+    'redhen_engagement',
+    'message',
+  ));
 
   field_delete_field('message_redhen_contact');
   field_delete_field('message_redhen_org');

--- a/campaignion_activity/src/NewsletterSubscription.php
+++ b/campaignion_activity/src/NewsletterSubscription.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\campaignion_activity;
 
-use \Drupal\campaignion\ContactTypeManager;
-use \Drupal\campaignion\CRM\Import\Source\ArraySource;
-use \Drupal\campaignion_newsletters\Subscription;
+use Drupal\campaignion\ContactTypeManager;
+use Drupal\campaignion\CRM\Import\Source\ArraySource;
+use Drupal\campaignion_newsletters\Subscription;
 
 /**
  * Partial model object to store newsletter subscription data for activities.

--- a/campaignion_activity/src/NewsletterSubscription.php
+++ b/campaignion_activity/src/NewsletterSubscription.php
@@ -16,6 +16,7 @@ class NewsletterSubscription extends ActivityBase {
   public $list_id;
   public $action;
   public $from_provider;
+  public $optin_statement;
 
   /**
    * Create a new activity object from a subscription object.
@@ -38,6 +39,7 @@ class NewsletterSubscription extends ActivityBase {
       'list_id' => $subscription->list_id,
       'action' => $action,
       'from_provider' => (int) $from_provider,
+      'optin_statement' => $subscription->optin_statement,
     ]);
   }
 
@@ -75,6 +77,7 @@ class NewsletterSubscription extends ActivityBase {
         'list_id',
         'action',
         'from_provider',
+        'optin_statement',
       ]))
       ->execute();
   }

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Campaignion newsletter component for webform.
@@ -78,7 +79,7 @@ function _webform_edit_newsletter($component) {
     '#description' => t('Which lists should the user be subscribed to?'),
     '#options' => $newsletters,
     '#weight' => 1,
-    // only relevant if type is 'select':
+    // Only relevant if type is 'select':
     '#empty_option' => t('Select newsletters'),
     '#multiple' => 1,
     '#select2' => array(),
@@ -120,7 +121,8 @@ function _webform_edit_newsletter($component) {
   ];
 
   $form['extra']['radio_labels'] = [
-    '#tree' => TRUE, // Needed for form_builder.
+    // Needed for form_builder.
+    '#tree' => TRUE,
     '#type' => 'fieldset',
     '#title' => t('Labels for the radios'),
     '#states' => ['visible' => ["#$display_id" => ['value' => 'radios']]],
@@ -145,6 +147,9 @@ function _webform_edit_newsletter($component) {
   return $form;
 }
 
+/**
+ * Validate function.
+ */
 function _webform_value_validate_newsletter(&$element, &$form_state) {
   $values = &drupal_array_get_nested_value($form_state['values'], $element['#parents']);
   $values = serialize($values);
@@ -176,6 +181,7 @@ function _webform_render_newsletter($component, $value = NULL, $filter = TRUE) {
         '#options' => $options,
       ];
       break;
+
     case 'radios':
       $l = $component['extra']['radio_labels'];
       $options = ['yes' => $l[1], 'no' => $l[0]];
@@ -196,11 +202,10 @@ function _webform_submit_newsletter($component, $value) {
   switch ($component['extra']['display']) {
     case 'checkbox':
       return empty($value['subscribed']) ? [''] : ['subscribed'];
-      break;
 
     case 'radios':
       return $value == 'yes' ? ['subscribed'] : [''];
-      break;
+
   }
 }
 
@@ -215,7 +220,7 @@ function _webform_display_newsletter($component, $value, $format = 'html') {
 /**
  * Form callback for the newsletter property.
  *
- * @see _webform_form_builder_map_newsletter().
+ * @see _webform_form_builder_map_newsletter()
  */
 function campaignion_newsletters_form_builder_property_newsletter_form(&$form_state, $form_type, $element, $property) {
   $form['options'] = array(
@@ -240,22 +245,21 @@ function campaignion_newsletters_form_builder_property_newsletter_form(&$form_st
 /**
  * Submit handler for the newsletter property.
  *
- * @see _webform_form_builder_map_newsletter().
+ * @see _webform_form_builder_map_newsletter()
  */
 function campaignion_newsletters_form_builder_property_newsletter_form_submit(&$form, &$form_state) {
   $form_state['values']['newsletter_lists'] = $form_state['values']['options']['lists'];
 }
-
 
 /**
  * Implements _webform_form_builder_properties_component().
  *
  * Component specific properties.
  * This is currently broken as the component specific properties are merged into
- * the global property list. That makes it behave the same way as an implementation
- * of hook_form_builder_properties().
+ * the global property list. That makes it behave the same way as an
+ * implementation of hook_form_builder_properties().
  *
- * @see form_builder_webform_form_builder_properties().
+ * @see form_builder_webform_form_builder_properties()
  */
 function _webform_form_builder_properties_newsletter() {
   return array(
@@ -275,6 +279,7 @@ function _webform_form_builder_properties_newsletter() {
 
 /**
  * Implements _webform_CALLBACK_TYPE().
+ *
  * Implements _webform_form_builder_map_TYPE().
  *
  * Defines mapping from webform component to form_builder element type.

--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -29,6 +29,7 @@ function _webform_defaults_newsletter() {
       'display' => 'checkbox',
       'radio_labels' => [t('No'), t('Yes, I want to subscribe to the newsletter')],
       'checkbox_label' => t('Subscribe me to the newsletter.'),
+      'optin_statement' => '',
     ),
   );
 }
@@ -135,6 +136,12 @@ function _webform_edit_newsletter($component) {
     ],
   ];
 
+  $form['extra']['optin_statement'] = [
+    '#type' => 'textarea',
+    '#title' => t('Opt-in statement'),
+    '#default_value' => $component['extra']['optin_statement'],
+  ];
+
   return $form;
 }
 
@@ -225,6 +232,7 @@ function campaignion_newsletters_form_builder_property_newsletter_form(&$form_st
   $form['newsletter_display'] = $edit['extra']['display'] + $dp;
   $form['newsletter_checkbox_label'] = $edit['extra']['checkbox_label'] + $dp;
   $form['newsletter_radio_labels'] = $edit['extra']['radio_labels'] + $dp;
+  $form['newsletter_optin_statement'] = $edit['extra']['optin_statement'];
 
   return $form;
 }
@@ -261,6 +269,7 @@ function _webform_form_builder_properties_newsletter() {
     'newsletter_display' => [],
     'newsletter_radio_labels' => [],
     'newsletter_checkbox_label' => [],
+    'newsletter_optin_statement' => [],
   );
 }
 
@@ -301,6 +310,9 @@ function _webform_form_builder_map_newsletter() {
     ],
     'newsletter_checkbox_label' => [
       'storage_parents' => ['extra', 'checkbox_label'],
+    ],
+    'newsletter_optin_statement' => [
+      'storage_parents' => ['extra', 'optin_statement'],
     ],
   );
   return $map;

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -105,6 +105,7 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
           $subscription->source = $s;
           $subscription->needs_opt_in = $needs_opt_in;
           $subscription->send_welcome = (bool) $component['extra']['send_welcome'];
+          $subscription->optin_statement = $component['extra']['optin_statement'];
           $subscription->optin_info = FormSubmission::fromWebformSubmission($s);
           $subscription->save();
         }

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -1,16 +1,17 @@
 <?php
+
 /**
  * @file
  * Campaignion newsletter module.
  */
 
-use \Drupal\campaignion_newsletters\CronRunner;
-use \Drupal\campaignion_newsletters\ProviderFactory;
-use \Drupal\campaignion_newsletters\FormSubmission;
-use \Drupal\campaignion_newsletters\Subscription;
-use \Drupal\campaignion_newsletters\Subscriptions;
-use \Drupal\campaignion\CRM\Import\Source\WebformSubmission;
-use \Drupal\little_helpers\Webform\Submission;
+use Drupal\campaignion_newsletters\CronRunner;
+use Drupal\campaignion_newsletters\ProviderFactory;
+use Drupal\campaignion_newsletters\FormSubmission;
+use Drupal\campaignion_newsletters\Subscription;
+use Drupal\campaignion_newsletters\Subscriptions;
+use Drupal\campaignion\CRM\Import\Source\WebformSubmission;
+use Drupal\little_helpers\Webform\Submission;
 
 /**
  * Implements hook_cron().
@@ -48,8 +49,8 @@ function campaignion_newsletters_permission() {
  */
 function campaignion_newsletters_menu() {
   $items['admin/config/services/campaignion_newsletters'] = array(
-    'title' => t('Newsletter settings'),
-    'description' => t('Configure newsletter API behavior'),
+    'title' => 'Newsletter settings',
+    'description' => 'Configure newsletter API behavior',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('campaignion_newsletters_admin_settings'),
     'access arguments' => array('administer newsletters'),
@@ -59,9 +60,9 @@ function campaignion_newsletters_menu() {
   return $items;
 }
 
-
 /**
  * Implements hook_form_FORM_ID_alter().
+ *
  * Implements hook_form_redhen_contact_contact_form_alter().
  */
 function campaignion_newsletters_form_redhen_contact_contact_form_alter(&$form, &$form_state) {
@@ -91,7 +92,7 @@ function campaignion_newsletters_webform_component_info() {
  */
 function campaignion_newsletters_webform_submission_confirmed(Submission $submission) {
   $s = new WebformSubmission($submission->node, $submission);
-  // use value of the component with key 'email' as email address
+  // Use value of the component with key 'email' as email address.
   if (!($email = $s->value('email'))) {
     return;
   }
@@ -119,17 +120,22 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
  *
  * Defines a new form_builder field:
  * - 'title'
- * - in which ['palette_group'] it appears. @see hook_form_builder_palette_groups().
- * - it's ['default'] representation (is used when dragging it into the preview area) including:
- *   - ['#webform_component'] the component array for webform (most important it's ['#webform_component']['type'].
- *     @see hook_webform_component_info().
- *   - ['#type'] the form-API type is used as the default form_builder element_type.
- *     @see hook_element_info().
+ * - in which ['palette_group'] it appears.
+ * - it's ['default'] representation (is used when dragging it into the preview
+ *   area) including:
+ *   - ['#webform_component'] the component array for webform (most important
+ *     it's ['#webform_component']['type'].
+ *   - ['#type'] the form-API type is used as the default form_builder
+ *     element_type.
  *   - ['#form_builder'] the form_builder type (again).
- *     @see hook_form_builder_element_types().
  * - whether or not the field is ['unique'].
  *
  * Fields are defined per form_type (so far only 'webform' is relevant for us).
+ *
+ * @see hook_form_builder_palette_groups()
+ * @see hook_webform_component_info()
+ * @see hook_element_info()
+ * @see hook_form_builder_element_types()
  */
 function campaignion_newsletters_form_builder_element_types($form_type, $form_id) {
   if ($form_type != 'webform') {
@@ -137,13 +143,13 @@ function campaignion_newsletters_form_builder_element_types($form_type, $form_id
   }
   require_once dirname(__FILE__) . '/campaignion_newsletters.component.inc';
   $map = _form_builder_webform_property_map('newsletter');
-  // default value is handled by the newsletter property.
+  // Default value is handled by the newsletter property.
   unset($map['properties']['default_value']);
   unset($map['properties']['description']);
   $fields['newsletter'] = array(
     'title' => t('Newsletter'),
     'properties' => array_keys($map['properties']),
-    'default' =>  array(
+    'default' => array(
       '#form_builder' => array('element_type' => 'newsletter'),
     ) + _form_builder_webform_default('newsletter'),
   );

--- a/campaignion_newsletters/src/Subscription.php
+++ b/campaignion_newsletters/src/Subscription.php
@@ -13,6 +13,7 @@ class Subscription extends \Drupal\little_helpers\DB\Model {
   public $source = NULL;
   public $needs_opt_in = FALSE;
   public $send_welcome = FALSE;
+  public $optin_statement = '';
   public $optin_info = NULL;
 
   public static $lists = array();

--- a/campaignion_newsletters/src/Subscription.php
+++ b/campaignion_newsletters/src/Subscription.php
@@ -2,7 +2,12 @@
 
 namespace Drupal\campaignion_newsletters;
 
-class Subscription extends \Drupal\little_helpers\DB\Model {
+use Drupal\little_helpers\DB\Model;
+
+/**
+ * Subscription model.
+ */
+class Subscription extends Model {
   public $list_id;
   public $email;
   public $fingerprint = '';
@@ -23,6 +28,14 @@ class Subscription extends \Drupal\little_helpers\DB\Model {
   protected static $values = array('fingerprint', 'updated', 'last_sync');
   protected static $serial = FALSE;
 
+  /**
+   * Get an instance from DB or create a new one.
+   *
+   * @param string $list_id
+   *   A list id.
+   * @param string $email
+   *   An email address.
+   */
   public static function byData($list_id, $email) {
     $result = db_select(static::$table, 's')
       ->fields('s')
@@ -31,11 +44,20 @@ class Subscription extends \Drupal\little_helpers\DB\Model {
       ->execute();
     if ($row = $result->fetch()) {
       return new static($row, FALSE);
-    } else {
+    }
+    else {
       return static::fromData($list_id, $email);
     }
   }
 
+  /**
+   * Construct a new instance from data.
+   *
+   * @param string $list_id
+   *   A list id.
+   * @param string $email
+   *   An email address.
+   */
   public static function fromData($list_id, $email) {
     return new static(array(
       'list_id' => $list_id,
@@ -43,6 +65,15 @@ class Subscription extends \Drupal\little_helpers\DB\Model {
     ), TRUE);
   }
 
+  /**
+   * Load all subscriptions for one email address.
+   *
+   * @param string $email
+   *   An email address.
+   *
+   * @return static[]
+   *   List of subscriptions.
+   */
   public static function byEmail($email) {
     $subscriptions = array();
     $result = db_select(static::$table, 's')
@@ -55,6 +86,12 @@ class Subscription extends \Drupal\little_helpers\DB\Model {
     return $subscriptions;
   }
 
+  /**
+   * Get the newsletter list instance.
+   *
+   * @return \Drupal\campaignion_newsletters\NewsletterList
+   *   The newsletter list for this subscription.
+   */
   public function newsletterList() {
     if (!isset(self::$lists[$this->list_id])) {
       self::$lists[$this->list_id] = NewsletterList::load($this->list_id);

--- a/campaignion_newsletters/tests/ComponentTest.php
+++ b/campaignion_newsletters/tests/ComponentTest.php
@@ -8,6 +8,24 @@ class ComponentTest extends \DrupalUnitTestCase {
     require_once drupal_get_path('module', 'campaignion_newsletters') . '/campaignion_newsletters.component.inc';
   }
 
+  public function testComponentDefaults() {
+    $defaults = webform_component_invoke('newsletter', 'defaults');
+
+    $expected_subset = array(
+      'extra' => array(
+        'opt_in_implied' => 1,
+        'send_welcome' => 0,
+        'optin_statement' => '',
+      )
+    );
+
+    $this->assertArraySubset($expected_subset, $defaults);
+
+    $component = webform_component_invoke('newsletter', 'edit', $defaults);
+
+    $this->assertEqual('textarea', $component['extra']['optin_statement']['#type']);
+  }
+
   public function testSubmitCheckbox() {
     $c['extra']['display'] = 'checkbox';
 


### PR DESCRIPTION
- provide a field on the component to set a statement for internal
  audit trail (will not be shown to users)
- save the text along the newsletter_subscription activity
- the activity is saved on confirmation (not on creation)