### PR TITLE
Don’t include .install files in coverage reports for now.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,7 +19,6 @@
     <directory suffix=".php">.</directory>
     <directory suffix=".inc">.</directory>
     <directory suffix=".module">.</directory>
-    <directory suffix=".install">.</directory>
     <exclude>
       <directory suffix="Test.php">.</directory>
       <directory suffix=".api.php">.</directory>


### PR DESCRIPTION
We don’t aim for coverage of the .install files for now instead we concentrate on the production code …