### PR TITLE
Make links default to `node` a path that is always accessible.

### DIFF
--- a/campaignion_bar/lib/MenuFileParser.php
+++ b/campaignion_bar/lib/MenuFileParser.php
@@ -85,7 +85,7 @@ class MenuFileParser {
 
     // Set default language
     $langs = array_keys(language_list());
-    $path = '';
+    $path = 'node';
 
     // JSON is used.
     if (($json_start = strpos($line, '{"')) != 0) {
@@ -100,7 +100,7 @@ class MenuFileParser {
       }
 
       // Extract details.
-      $path              = !empty($details->url) ? trim($details->url) : '';
+      $path              = !empty($details->url) ? trim($details->url) : $path;
       $item->description = !empty($details->description) ? trim($details->description) : '';
       $item->expanded    = !empty($details->expanded);
       $item->hidden      = !empty($details->hidden);


### PR DESCRIPTION
This fixes an issue where the campaignion_bar links vanish when the
front page is not accessible by the currently logged-in user.