### PR TITLE
opt-in: Handle empty value for private or hidden components.

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters.component.inc
+++ b/campaignion_newsletters/campaignion_newsletters.component.inc
@@ -286,6 +286,9 @@ function _webform_newsletter_value_to_label($value) {
     case 'radios:not-selected':
       return t('Radio not selected (no change)');
 
+    case '':
+      return t('Private or hidden by conditionals (no change)');
+
     default:
       return t('Unknown value');
   }

--- a/campaignion_newsletters/campaignion_newsletters.conditionals.js
+++ b/campaignion_newsletters/campaignion_newsletters.conditionals.js
@@ -3,11 +3,14 @@
  * Conditional operators for newsletter fields.
  */
 
-(function () {
+(function ($) {
 
   "use strict";
   Drupal.webform = Drupal.webform || {};
   Drupal.webform.conditionalOperatorNewsletterEqual = function (element, existingValue, ruleValue) {
+    if ($(element).closest('.webform-conditional-hidden').length > 0) {
+      return false;
+    }
     var checkbox = element.querySelector('.form-type-checkbox input');
     if (checkbox) {
       return checkbox.checked ? ruleValue === 'checkbox:opt-in' : ruleValue === 'checkbox:no-change';
@@ -24,4 +27,4 @@
     return !Drupal.webform.conditionalOperatorNewsletterEqual(element, existingValue, ruleValue);
   };
 
-})();
+})(jQuery);

--- a/campaignion_newsletters/tests/WebformComponentTest.php
+++ b/campaignion_newsletters/tests/WebformComponentTest.php
@@ -90,6 +90,7 @@ class WebformComponentTest extends \DrupalUnitTestCase {
     $this->assertEqual(t('Checkbox no change'), $export(['checkbox:no-change']));
     $this->assertEqual(t('Radio no change'), $export(['radios:no-change']));
     $this->assertEqual(t('Radio not selected (no change)'), $export(['radios:not-selected']));
+    $this->assertEqual(t('Private or hidden by conditionals (no change)'), $export(['']));
   }
 
   /**
@@ -107,6 +108,7 @@ class WebformComponentTest extends \DrupalUnitTestCase {
     $this->assertEqual(t('Checkbox no change'), $export(['checkbox:no-change']));
     $this->assertEqual(t('Radio no change'), $export(['radios:no-change']));
     $this->assertEqual(t('Radio not selected (no change)'), $export(['radios:not-selected']));
+    $this->assertEqual(t('Private or hidden by conditionals (no change)'), $export(['']));
   }
 
   /**

--- a/campaignion_opt_in/campaignion_opt_in.component.inc
+++ b/campaignion_opt_in/campaignion_opt_in.component.inc
@@ -229,6 +229,9 @@ function _webform_opt_in_value_to_label($value) {
     case 'radios:' . Values::NOT_SELECTED:
       return t('Radio not selected (no change)');
 
+    case '':
+      return t('Private or hidden by conditionals (no change)');
+
     default:
       return t('Unknown value');
   }

--- a/campaignion_opt_in/campaignion_opt_in.conditionals.js
+++ b/campaignion_opt_in/campaignion_opt_in.conditionals.js
@@ -3,11 +3,14 @@
  * Conditional operators for newsletter fields.
  */
 
-(function () {
+(function ($) {
 
   "use strict";
   Drupal.webform = Drupal.webform || {};
   Drupal.webform.conditionalOperatorOptInEqual = function (element, existingValue, ruleValue) {
+    if ($(element).closest('.webform-conditional-hidden').length > 0) {
+      return false;
+    }
     var checkbox = element.querySelector('.form-type-checkbox input');
     if (checkbox) {
       var isInverted = checkbox.value === 'no-change';
@@ -27,4 +30,4 @@
     return !Drupal.webform.conditionalOperatorOptInEqual(element, existingValue, ruleValue);
   };
 
-})();
+})(jQuery);

--- a/campaignion_opt_in/tests/ComponentTest.php
+++ b/campaignion_opt_in/tests/ComponentTest.php
@@ -128,6 +128,7 @@ class ComponentTest extends \DrupalUnitTestCase {
     $this->assertEqual(t('Radio not selected (no change)'), $export(['radios:not-selected']));
     $this->assertEqual(t('Inverted checkbox opt-in'), $export(['checkbox-inverted:opt-in']));
     $this->assertEqual(t('Inverted checkbox no change'), $export(['checkbox-inverted:no-change']));
+    $this->assertEqual(t('Private or hidden by conditionals (no change)'), $export(['']));
   }
 
   /**
@@ -147,6 +148,7 @@ class ComponentTest extends \DrupalUnitTestCase {
     $this->assertEqual(t('Radio not selected (no change)'), $export(['radios:not-selected']));
     $this->assertEqual(t('Inverted checkbox opt-in'), $export(['checkbox-inverted:opt-in']));
     $this->assertEqual(t('Inverted checkbox no change'), $export(['checkbox-inverted:no-change']));
+    $this->assertEqual(t('Private or hidden by conditionals (no change)'), $export(['']));
   }
 
   /**


### PR DESCRIPTION
This changes campaignion_newsletters as well.