### PR TITLE
Fix redirect filter config change

### DIFF
--- a/campaignion_action/src/Redirects/Filter.php
+++ b/campaignion_action/src/Redirects/Filter.php
@@ -29,24 +29,26 @@ class Filter extends Model {
    *   Data representing the filter.
    */
   public static function fromArray(array $data) {
-    $config = $data + ['id' => NULL, 'weight' => 0];
-    unset($config['redirect_id']);
-    $data = [];
-    foreach (['id', 'weight', 'type'] as $k) {
-      $data[$k] = $config[$k];
-      unset($config[$k]);
-    }
-    $data['config'] = $config;
-    return new static($data);
+    $data += ['id' => NULL, 'weight' => 0];
+    $filter = new static();
+    $filter->id = $data['id'];
+    $filter->setData($data);
+    return $filter;
   }
 
   /**
    * Update filter data from array.
    */
-  public function setData($data) {
+  public function setData(array $data) {
     unset($data['id']);
     unset($data['redirect_id']);
-    $this->__construct($data);
+    foreach (['weight', 'type'] as $k) {
+      if (isset($data[$k])) {
+        $this->{$k} = $data[$k];
+        unset($data[$k]);
+      }
+    }
+    $this->config = $data;
   }
 
   /**

--- a/campaignion_action/tests/Redirects/EndpointTest.php
+++ b/campaignion_action/tests/Redirects/EndpointTest.php
@@ -97,7 +97,7 @@ class EndpointTest extends \DrupalWebTestCase {
   }
 
   /**
-   * Test updating filters.
+   * Test replacing a filter.
    */
   public function testPutExchangeFilter() {
     $data = ['nid' => 1, 'delta' => 0];
@@ -122,6 +122,24 @@ class EndpointTest extends \DrupalWebTestCase {
     $this->assertEqual(1, count($answer));
     $this->assertEqual(1, count($answer[0]['filters']));
     $this->assertEqual(2, $answer[0]['filters'][0]['test']);
+  }
+
+  /**
+   * Test changing a filter value.
+   */
+  public function testPutChangeFilterValue() {
+    $data = ['nid' => 1, 'delta' => 0];
+    $filter = Filter::fromArray(['test' => 'unchanged', 'type' => 'test']);
+    $r1 = new Redirect(['label' => 'First', 'filters' => [$filter]] + $data);
+    $r1->save();
+
+    $fakenode = (object) ['nid' => 1];
+    $endpoint = new Endpoint($fakenode, 0);
+
+    $data = $endpoint->get();
+    $data['redirects'][0]['filters'][0]['test'] = 'changed';
+    $new_data = $endpoint->put($data);
+    $this->assertEqual($data, $new_data);
   }
 
 }

--- a/campaignion_action/tests/Redirects/FilterTest.php
+++ b/campaignion_action/tests/Redirects/FilterTest.php
@@ -156,4 +156,17 @@ class FilterTest extends \DrupalWebTestCase {
     $this->assertFalse($fs->match($submission));
   }
 
+  /**
+   * Test changing config with setData.
+   */
+  public function testSetDataChangeConfig() {
+    $c = ['type' => 'test', 'test' => 'unchanged'];
+    $f = Filter::fromArray($c);
+    $this->assertEqual('unchanged', $f->config['test']);
+
+    $c['test'] = 'changed';
+    $f->setData($c);
+    $this->assertEqual('changed', $f->config['test']);
+  }
+
 }


### PR DESCRIPTION
The bug means that changing a filter in the UI doesn’t work, however deleting and adding a new one does.