### PR TITLE
Fix: Using isset() to field instances doesn’t work for new entities.

### DIFF
--- a/campaignion_source_tags/campaignion_source_tags.module
+++ b/campaignion_source_tags/campaignion_source_tags.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Code for the Campaignion source tags feature.
@@ -31,8 +32,8 @@ function campaignion_source_tags_campaignion_action_contact_alter($contact, $sub
  * Implements hook_entity_presave().
  */
 function campaignion_source_tags_entity_presave($entity, $entity_type) {
-  if (isset($entity->supporter_tags) && isset($entity->source_tag)) {
-    $wrapped = entity_metadata_wrapper($entity_type, $entity);
+  $wrapped = entity_metadata_wrapper($entity_type, $entity);
+  if (isset($wrapped->supporter_tags) && isset($wrapped->source_tag)) {
     if (!$wrapped->source_tag->value()) {
       foreach ($wrapped->supporter_tags->value() as $term) {
         // Check whether the term is a source tag.

--- a/campaignion_source_tags/tests/SourceTagTest.php
+++ b/campaignion_source_tags/tests/SourceTagTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\campaignion_source_tags;
 
+use Drupal\campaignion\Contact;
 use Drupal\campaignion\CRM\ImporterBase;
 use Drupal\campaignion\CRM\Import\Field\Name;
 use Drupal\campaignion\CRM\Import\Source\ArraySource;
@@ -11,6 +12,8 @@ use Drupal\campaignion_supporter_tags\Tagger;
  * Test for setting source tags.
  */
 class SourceTagTest extends \DrupalWebTestCase {
+
+  protected $testEmail = 'testsetsourcetagduringimport@example.com';
 
   /**
    * Test setting the source tag during an import.
@@ -25,14 +28,22 @@ class SourceTagTest extends \DrupalWebTestCase {
     $source = new ArraySource([
       'first_name' => 'F',
       'last_name' => 'L',
-      'email' => 'testsetsourcetagduringimport@example.com',
+      'email' => $this->testEmail,
     ]);
     $contact = $importer->findOrCreateContact($source);
     $tagger->tag($contact->supporter_tags, ['test-source'], TRUE);
     $importer->import($source, $contact);
     $contact->save();
     $this->assertNotEmpty($contact->source_tag[LANGUAGE_NONE][0]);
-    entity_delete('redhen_contact', $contact->contact_id);
+  }
+
+  /**
+   * Delete test contact.
+   */
+  public function tearDown() {
+    if ($contact = Contact::byEmail($this->testEmail)) {
+      $contact->delete();
+    }
   }
 
 }


### PR DESCRIPTION
campaignion_source_tag used `isset($entity->field_name)` to check whether an entity has a particular field. This does not work for new entities though. It seems the field attributes are not set on entity creation but only when the entity is first loaded from the database.