### PR TITLE
Allow headless nightwatch tests

### DIFF
--- a/campaignion_wizard/redirects_app/test/e2e/nightwatch.conf.js
+++ b/campaignion_wizard/redirects_app/test/e2e/nightwatch.conf.js
@@ -36,7 +36,10 @@ module.exports = {
       desiredCapabilities: {
         browserName: 'chrome',
         javascriptEnabled: true,
-        acceptSslCerts: true
+        acceptSslCerts: true,
+        chromeOptions : {
+            args: process.env.HEADLESS ? ["headless", "no-sandbox", "disable-gpu"] : []
+        }
       }
     },
 


### PR DESCRIPTION
`redirects_app`: run tests with `HEADLESS=1 yarn e2e` for headless browser