### PR TITLE
campaignion_newsletters: Make conditionals not fail with ajax.

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters.conditionals.js
+++ b/campaignion_newsletters/campaignion_newsletters.conditionals.js
@@ -8,6 +8,9 @@
   "use strict";
   Drupal.webform = Drupal.webform || {};
   Drupal.webform.conditionalOperatorNewsletterEqual = function (element, existingValue, ruleValue) {
+    if (!element) {
+      return false;
+    }
     if ($(element).closest('.webform-conditional-hidden').length > 0) {
       return false;
     }

--- a/campaignion_opt_in/campaignion_opt_in.conditionals.js
+++ b/campaignion_opt_in/campaignion_opt_in.conditionals.js
@@ -8,6 +8,9 @@
   "use strict";
   Drupal.webform = Drupal.webform || {};
   Drupal.webform.conditionalOperatorOptInEqual = function (element, existingValue, ruleValue) {
+    if (!element) {
+      return false;
+    }
     if ($(element).closest('.webform-conditional-hidden').length > 0) {
       return false;
     }


### PR DESCRIPTION
With webform_ajax conditional rule groups accumulate in in the `Drupal.settings.webform.conditionals`. That means JS for a conditional for on one page is executed on all later pages as well. This means conditional operators need to deal with non-existent elements.

Upstream issue: https://www.drupal.org/project/webform/issues/3005684