### PR TITLE
Conditionals: Support for multi-page rule groups.

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters.conditionals.js
+++ b/campaignion_newsletters/campaignion_newsletters.conditionals.js
@@ -6,22 +6,30 @@
 (function ($) {
 
   "use strict";
+
+  var getValue = function (element, existingValue) {
+    if (existingValue) {
+      return existingValue[0];
+    }
+    if (element) {
+      if ($(element).closest('.webform-conditional-hidden').length > 0) {
+        return null;
+      }
+      var checkbox = element.querySelector('.form-type-checkbox input');
+      if (checkbox) {
+        return checkbox.checked ? 'checkbox:opt-in' : 'checkbox:no-change';
+      }
+      var radio = element.querySelector('.form-type-radio input');
+      if (radio) {
+        var radioChecked = element.querySelector('.form-type-radio input:checked');
+        var radioValue = radioChecked ? radioChecked.value : 'not-selected';
+        return 'radios:' + radioValue;
+      }
+    }
+  };
   Drupal.webform = Drupal.webform || {};
   Drupal.webform.conditionalOperatorNewsletterEqual = function (element, existingValue, ruleValue) {
-    if ($(element).closest('.webform-conditional-hidden').length > 0) {
-      return false;
-    }
-    var checkbox = element.querySelector('.form-type-checkbox input');
-    if (checkbox) {
-      return checkbox.checked ? ruleValue === 'checkbox:opt-in' : ruleValue === 'checkbox:no-change';
-    }
-    var radio = element.querySelector('.form-type-radio input');
-    if (radio) {
-      var radioChecked = element.querySelector('.form-type-radio input:checked');
-      var radioValue = radioChecked ? radioChecked.value : 'not-selected';
-      return 'radios:' + radioValue === ruleValue;
-    }
-    return false;
+    return getValue(element, existingValue) === ruleValue;
   };
   Drupal.webform.conditionalOperatorNewsletterNotEqual = function (element, existingValue, ruleValue) {
     return !Drupal.webform.conditionalOperatorNewsletterEqual(element, existingValue, ruleValue);

--- a/campaignion_opt_in/campaignion_opt_in.conditionals.js
+++ b/campaignion_opt_in/campaignion_opt_in.conditionals.js
@@ -6,25 +6,33 @@
 (function ($) {
 
   "use strict";
+
+  var getValue = function (element, existingValue) {
+    if (existingValue) {
+      return existingValue[0];
+    }
+    if (element) {
+      if ($(element).closest('.webform-conditional-hidden').length > 0) {
+        return null;
+      }
+      var checkbox = element.querySelector('.form-type-checkbox input');
+      if (checkbox) {
+        var uncheckedValue = checkbox.getAttribute('data-no-value');
+        var prefix = checkbox.getAttribute('data-prefix');
+        var value = checkbox.checked ? checkbox.value : uncheckedValue;
+        return prefix + ':' + value;
+      }
+      var radio = element.querySelector('.form-type-radio input');
+      if (radio) {
+        var radioChecked = element.querySelector('.form-type-radio input:checked');
+        var radioValue = radioChecked ? radioChecked.value : 'not-selected';
+        return 'radios:' + radioValue;
+      }
+    }
+  };
   Drupal.webform = Drupal.webform || {};
   Drupal.webform.conditionalOperatorOptInEqual = function (element, existingValue, ruleValue) {
-    if ($(element).closest('.webform-conditional-hidden').length > 0) {
-      return false;
-    }
-    var checkbox = element.querySelector('.form-type-checkbox input');
-    if (checkbox) {
-      var uncheckedValue = checkbox.getAttribute('data-no-value');
-      var prefix = checkbox.getAttribute('data-prefix');
-      var value = checkbox.checked ? checkbox.value : uncheckedValue;
-      return ruleValue === prefix + ':' + value;
-    }
-    var radio = element.querySelector('.form-type-radio input');
-    if (radio) {
-      var radioChecked = element.querySelector('.form-type-radio input:checked');
-      var radioValue = radioChecked ? radioChecked.value : 'not-selected';
-      return 'radios:' + radioValue === ruleValue;
-    }
-    return false;
+    return ruleValue === getValue(element, existingValue);
   };
   Drupal.webform.conditionalOperatorOptInNotEqual = function (element, existingValue, ruleValue) {
     return !Drupal.webform.conditionalOperatorOptInEqual(element, existingValue, ruleValue);


### PR DESCRIPTION
`existingValue` is used when a conditional rule group spans multiple pages. Values for components from earlier pages are then passed as `existingValue` because the `element` does not exist on this page.

*In an ideal world webform would interpret these rules on the server-side. If it were the case there would be no need for the `existingValue` parameter.*