### PR TITLE
campaignion_manage pager: Use PHP’s parse_url().

### DIFF
--- a/campaignion_manage/campaignion_manage.theme.inc
+++ b/campaignion_manage/campaignion_manage.theme.inc
@@ -90,7 +90,7 @@ function theme_campaignion_manage_pager($variables) {
   $element['#theme'] = 'pager';
   $old_q = $_GET['q'];
   if ($old_q == 'system/ajax' && !empty($_SERVER['HTTP_REFERER'])) {
-    $url = drupal_parse_url($_SERVER['HTTP_REFERER']);
+    $url = parse_url($_SERVER['HTTP_REFERER']);
     $_GET['q'] = $url['path'];
   }
   $output = drupal_render($element);

--- a/campaignion_manage/tests/ThemeTest.php
+++ b/campaignion_manage/tests/ThemeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\campaignion_manage;
+
+/**
+ * Test theme function for campaignion_manage.
+ */
+class ThemeTest extends \DrupalUnitTestCase {
+
+  /**
+   * Test parse_url with absolute URL.
+   */
+  public function testParseUrlAbsolute() {
+    $element = [
+      '#theme' => 'campaignion_manage_pager',
+      '#element' => pager_default_initialize(20, 5),
+    ];
+    $_GET['q'] = 'system/ajax';
+    $_SERVER['HTTP_REFERER'] = 'http://example.com/path';
+    $html = drupal_render($element);
+    $this->assertContains('href="/path?page=1"', $html);
+  }
+
+}

--- a/campaignion_test/campaignion_test.info
+++ b/campaignion_test/campaignion_test.info
@@ -9,6 +9,7 @@ dependencies[] = campaignion_activity
 dependencies[] = campaignion_email_to_target
 dependencies[] = campaignion_email_to_target_counter
 dependencies[] = campaignion_form_builder
+dependencies[] = campaignion_manage
 dependencies[] = campaignion_mp_fields
 dependencies[] = campaignion_newsletters
 dependencies[] = campaignion_newsletters_mailchimp


### PR DESCRIPTION
drupal_parse_url() does not handle absolute URLs and as such is not suitable for parsing the referer.