### PR TITLE
Backlog: save as draft (unpublish)

### DIFF
--- a/campaignion_wizard/src/ConfirmStep.php
+++ b/campaignion_wizard/src/ConfirmStep.php
@@ -68,7 +68,7 @@ class ConfirmStep extends WizardStep {
     ];
     $buttons['draft'] = [
       '#type' => 'submit',
-      '#value' => t('Save as draft'),
+      '#value' => t('Save as draft (unpublish)'),
       '#name' => 'draft',
       '#weight' => 1020,
       '#wizard type' => 'return',

--- a/campaignion_wizard/src/WizardStep.php
+++ b/campaignion_wizard/src/WizardStep.php
@@ -30,7 +30,7 @@ abstract class WizardStep extends _WizardStep {
     $form['buttons']['next']['#value'] = t('Next');
 
     if (isset($form['buttons']['return'])) {
-      $label = (isset($this->wizard->node->status) && $this->wizard->node->status) ? t('Save & return') : t('Save as draft');
+      $label = (isset($this->wizard->node->status) && $this->wizard->node->status) ? t('Save & return') : t('Save as draft (unpublish)');
       $form['buttons']['return']['#value'] = $label;
     }
     return $form;

--- a/campaignion_wizard/translations/ae_wizard.pot
+++ b/campaignion_wizard/translations/ae_wizard.pot
@@ -116,7 +116,7 @@ msgid "Schedule publishing"
 msgstr ""
 
 #: modules/ae_wizard/includes/wizard.inc.php:259
-msgid "Save as draft"
+msgid "Save as draft (unpublish)"
 msgstr ""
 
 #: modules/ae_wizard/plugins/donation.inc.php:53

--- a/campaignion_wizard/translations/de.pot
+++ b/campaignion_wizard/translations/de.pot
@@ -120,8 +120,8 @@ msgid "Schedule publishing"
 msgstr "Zeitgesteuerte Veröffentlichung"
 
 #: modules/ae_wizard/includes/wizard.inc.php:259
-msgid "Save as draft"
-msgstr "Als Entwurf speichern"
+msgid "Save as draft (unpublish)"
+msgstr "Als Entwurf speichern (Veröffentlichung rückgängig machen)"
 
 #: modules/ae_wizard/plugins/donation.inc.php:53
 #: modules/ae_wizard/plugins/petition.inc.php:52


### PR DESCRIPTION
Rename "Save as draft" from the Confirm step of an action to "Save as draft (unpublish)"

German translation might need to be improved!

Request: https://trello.com/c/jhTQRAIy
