### PR TITLE
Form Builder: rename Newsletter field to 'Email Opt-In'

### DIFF
--- a/campaignion_form_builder/campaignion_form_builder.type_select.inc
+++ b/campaignion_form_builder/campaignion_form_builder.type_select.inc
@@ -46,7 +46,7 @@ function _campaignion_form_builder_form_builder_types_select() {
     ['1' => t("Yes, I'd like to get email newsletters")],
     -69
   );
-  $fields['email_newsletter']['title'] = t('Newsletter');
+  $fields['email_newsletter']['title'] = t('Email Opt-In');
   $fields['email_newsletter']['default']['#form_builder']['element_type'] = 'checkboxes';
 
   return $fields;

--- a/campaignion_form_builder/translations/de.po
+++ b/campaignion_form_builder/translations/de.po
@@ -53,6 +53,10 @@ msgstr "anders"
 msgid "Newsletter"
 msgstr "Newsletter"
 
+#: modules/campaignion_form_builder/campaignion_form_builder.module:83
+msgid "Email Opt-In"
+msgstr "E-Mail Opt-In"
+
 #: modules/campaignion_form_builder/campaignion_form_builder.module:86
 msgid "Yes, I'd like to get email newsletters"
 msgstr "Ja, ich möchte den E-Mail Newsletter erhalten"


### PR DESCRIPTION
Rename Newsletter field to 'Email Opt-In' in Form Builder to match the phone and post opt-in fields.

To clear: German translation

Requested by: https://trello.com/c/El4Cwg5N