### PR TITLE
Update RandomLib libraries spec.

### DIFF
--- a/campaignion_email_to_target/campaignion_email_to_target.module
+++ b/campaignion_email_to_target/campaignion_email_to_target.module
@@ -180,9 +180,9 @@ function campaignion_email_to_target_libraries_info() {
   ];
   $libraries['RandomLib'] = [
     'name' => 'RandomLib — A library for generating random numbers and strings of various strengths.',
-    'vendor url' => 'https://github.com/ircmaxell/RandomLib',
-    'download url' => 'https://github.com/ircmaxell/RandomLib',
-    'version' => '1.1.0',
+    'vendor url' => 'https://github.com/paragonie/RandomLib',
+    'download url' => 'https://github.com/paragonie/RandomLib',
+    'version' => '2.0.0',
     'xautoload' => function ($adapter) {
       $adapter->composerJson('composer.json');
     },


### PR DESCRIPTION
- the additional dependencies from the composer.json are not strictly
  necessary:
  * paragonie/random_compat is only necessary for PHP 5
  * paragonie/sodium_compat is a high strengh mixer, but by default the
    low strengh crypto get's loaded and there is an alternative for high
    strenght mixers (McryptRijndael128)