### PR TITLE
Use contact.display_name as label for the target selector.

### DIFF
--- a/campaignion_email_to_target/src/Component.php
+++ b/campaignion_email_to_target/src/Component.php
@@ -122,7 +122,7 @@ class Component {
       ];
       $t['send'] = [
         '#type' => 'checkbox',
-        '#title' => $target['salutation'],
+        '#title' => $message->display,
         '#default_value' => TRUE,
       ];
       $t['subject'] = [

--- a/campaignion_email_to_target/src/Message.php
+++ b/campaignion_email_to_target/src/Message.php
@@ -15,9 +15,15 @@ class Message {
   public $header;
   public $message;
   public $footer;
-  protected $tokenEnabledFields = ['to', 'from', 'subject', 'header', 'message', 'footer'];
+  public $display;
+  protected $tokenEnabledFields = ['to', 'from', 'subject', 'header', 'message', 'footer', 'display'];
 
   public function __construct($data) {
+    $data += [
+      'from' => '[submission:values:first_name] [submission:values:last_name] <[submission:values:email]>',
+      'to' => '[email-to-target:contact.title] [email-to-target:contact.first_name] [email-to-target:contact.last_name] <[email-to-target:contact.email]>',
+      'display' => '[email-to-target:contact.display_name]',
+    ];
     foreach ($data as $k => $v) {
       $this->$k = $v;
     }
@@ -31,13 +37,13 @@ class Message {
       'message' => $t->message,
       'footer' => $t->footer,
     ];
-    return new static($data + [
-      'from' => '[submission:values:first_name] [submission:values:last_name] <[submission:values:email]>',
-      'to' => '[email-to-target:contact.title] [email-to-target:contact.first_name] [email-to-target:contact.last_name] <[email-to-target:contact.email]>',
-    ]);
+    return new static($data);
   }
 
   public function replaceTokens($target = NULL, $submission = NULL, $clear = FALSE) {
+    if (empty($target['display_name']) && !empty($target['salutation'])) {
+      $target['display_name'] = $target['salutation'];
+    }
     $data['email-to-target'] = $target;
     $data['webform-submission'] = $submission;
     if ($submission instanceof Submission) {

--- a/campaignion_email_to_target/src/Wizard/TargetStep.php
+++ b/campaignion_email_to_target/src/Wizard/TargetStep.php
@@ -49,7 +49,12 @@ class TargetStep extends \Drupal\campaignion_wizard\WizardStep {
         'key' => 'salutation',
         'description' => 'Full name and titles',
         'title' => 'Salutation',
-      ]
+      ],
+      [
+        'key' => 'display_name',
+        'title' => 'Display name of target',
+        'description' => 'The name/description of the target that the users see',
+      ],
     ];
     $settings['validations'] = [              // used by the front end, a set of 'key' => 'regex' pairs
       'email' => '^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$', // backslashes have to be escaped so JS won’t interpret them as escape sequence.

--- a/campaignion_email_to_target/src/Wizard/TargetStep.php
+++ b/campaignion_email_to_target/src/Wizard/TargetStep.php
@@ -55,6 +55,11 @@ class TargetStep extends \Drupal\campaignion_wizard\WizardStep {
         'title' => 'Display name of target',
         'description' => 'The name/description of the target that the users see',
       ],
+      [
+        'key' => 'group',
+        'title' => 'Group',
+        'description' => '',
+      ],
     ];
     $settings['validations'] = [              // used by the front end, a set of 'key' => 'regex' pairs
       'email' => '^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$', // backslashes have to be escaped so JS won’t interpret them as escape sequence.

--- a/campaignion_email_to_target/tests/ComponentTest.php
+++ b/campaignion_email_to_target/tests/ComponentTest.php
@@ -119,7 +119,20 @@ class ComponentTest extends \DrupalUnitTestCase {
     $element['#parents'] = [];
     $component->validate($element, $form_state);
     $this->assertEqual(count($form_state['values']), 2);
+  }
 
+  /**
+   * Test that display is used as label for the targets.
+   */
+  public function testRenderDisplayName() {
+    list($component, $submission_o) = $this->mockComponent([
+      [['id' => 't1'], new Message(['display' => 'D1'])],
+    ], ['selection_mode' => 'all']);
+    $element = [];
+    $form = [];
+    $form_state = form_state_defaults();
+    $component->render($element, $form, $form_state);
+    $this->assertContains('D1', $element['t1']['send']['#markup']);
   }
 
 }

--- a/campaignion_email_to_target/tests/MessageTest.php
+++ b/campaignion_email_to_target/tests/MessageTest.php
@@ -30,6 +30,22 @@ class MessageTest extends \DrupalUnitTestCase {
   }
 
   /**
+   * Test rendering display_name token with fallback to salutation.
+   */
+  public function testRenderDisplayNameToken() {
+    $target = ['salutation' => 'S'];
+    $message = new Message([]);
+    $this->assertContains('contact.display_name', $message->display);
+    $message->replaceTokens($target);
+    $this->assertEqual('S', $message->display);
+
+    $target = ['display_name' => 'D', 'salutation' => 'S'];
+    $message = new Message([]);
+    $message->replaceTokens($target);
+    $this->assertEqual('D', $message->display);
+  }
+
+  /**
    * Test replacing tokens from a hidden component.
    */
   public function testReplaceTokensWithHiddenComponent() {


### PR DESCRIPTION
This is needed because salutation is usually used for the heading of the email message itself.

- Hardcode `contact.display_name` instead of `contact.salutation`.
- Backwards compatibility: Fall back to `contact.salutation` if `contact.display_name` is not available.