### PR TITLE
Address import: Trim more whitespace earlier.

### DIFF
--- a/src/CRM/Import/Field/Address.php
+++ b/src/CRM/Import/Field/Address.php
@@ -13,10 +13,19 @@ class Address extends Field {
     parent::__construct($field, $mapping);
   }
 
+  /**
+   * Trim and normalize the source value.
+   */
+  protected static function valueFromSource(SourceInterface $source, $keys) {
+    if ($value = parent::valueFromSource($source, $keys)) {
+      return preg_replace('/\s+/', ' ', trim($value));
+    }
+  }
+
   public function getValue(SourceInterface $source) {
     $address = array();
     foreach ($this->source as $target => $keys) {
-      $value = self::valueFromSource($source, $keys);
+      $value = static::valueFromSource($source, $keys);
       if ($value) {
         $address[$target] = $value;
       }
@@ -52,9 +61,6 @@ class Address extends Field {
   }
 
   public function setValue(\EntityMetadataWrapper $entity, $new_address) {
-    // Trim all whitespace from start and end of input strings.
-    $new_address = array_map('trim', $new_address);
-
     $field = $entity->{$this->field};
     if ($field instanceof \EntityListWrapper) {
       return $this->setValueMultiple($field, $new_address);

--- a/test/CRM/Import/Field/AddressTest.php
+++ b/test/CRM/Import/Field/AddressTest.php
@@ -20,7 +20,7 @@ class AddressTest extends RedhenEntityTest {
     'country' => 'AT',
   );
 
-  static protected function mapped(&$data) {
+  static protected function mapped($data) {
     $mapped = array();
     foreach (self::$mapping as $field_key => $data_key) {
       if (isset($data[$data_key])) {
@@ -41,6 +41,7 @@ class AddressTest extends RedhenEntityTest {
    * Set up test data.
    */
   public function setUp() {
+    parent::setUp();
     $this->importer = new Address('field_address', self::$mapping);
     $this->contact = $this->newRedhenContact();
     $this->fakeContact = $this->createMock('EntityMetadataWrapper');
@@ -111,6 +112,19 @@ class AddressTest extends RedhenEntityTest {
     // Add rest of the address data.
     $source = new ArraySource(self::$testdata);
     $expected = $this->mapped(self::$testdata);
+    $changed = $this->importer->import($source, $this->fakeContact);
+    $this->assertTrue($changed);
+    $this->assertEqual($expected, $this->contact->field_address->value()[0]);
+  }
+
+  /**
+   * Test importing address with multiple spaces.
+   */
+  public function testImportMultipleSpaces() {
+    $data['street_address'] = 'Multiple  spaces ';
+    $source = new ArraySource($data);
+    $expected = $this->mapped(['street_address' => 'Multiple spaces']);
+
     $changed = $this->importer->import($source, $this->fakeContact);
     $this->assertTrue($changed);
     $this->assertEqual($expected, $this->contact->field_address->value()[0]);


### PR DESCRIPTION
field_address seems to trim multiple whitespaces on save. We need to do the same otherwise reimporting multiple imports always add yet another address item.