### PR TITLE
Reuse the CsvExporter in campaignion_manage.

### DIFF
--- a/campaignion_manage/src/BulkOp/SupporterExport.php
+++ b/campaignion_manage/src/BulkOp/SupporterExport.php
@@ -13,7 +13,7 @@ class SupporterExport implements BatchInterface {
   }
 
   private function getFields() {
-    $exporter = ContactTypeManager::instance()->exporter('campaignion_manage');
+    $exporter = ContactTypeManager::instance()->exporter('csv');
     return $exporter->columnOptions();
   }
 
@@ -50,7 +50,7 @@ class SupporterExport implements BatchInterface {
    * Create the temporary file and add the header lines.
    */
   protected function initBatch(&$data) {
-    $exporter = ContactTypeManager::instance()->exporter('campaignion_manage');
+    $exporter = ContactTypeManager::instance()->exporter('csv');
     $exporter->filterColumns($data['fields']);
     $handle = fopen($data['csv_name'], 'w');
     fputcsv($handle, $exporter->header(0));

--- a/campaignion_manage/src/BulkOp/SupporterExport.php
+++ b/campaignion_manage/src/BulkOp/SupporterExport.php
@@ -2,7 +2,8 @@
 
 namespace Drupal\campaignion_manage\BulkOp;
 
-use \Drupal\campaignion_manage\BatchJob;
+use Drupal\campaignion\ContactTypeManager;
+use Drupal\campaignion_manage\BatchJob;
 
 class SupporterExport implements BatchInterface {
   public function title() { return t('Export contact data'); }
@@ -12,37 +13,22 @@ class SupporterExport implements BatchInterface {
   }
 
   private function getFields() {
-    $fields = array(
-        'first_name' => 'First name',
-        'middle_name' => 'Middle name',
-        'last_name' => 'Last name',
-    );
-
-    foreach (field_info_instances('redhen_contact', 'contact') as $name => $field) {
-      $fields[$name] = $field['label'];
-    }
-    return $fields;
+    $exporter = ContactTypeManager::instance()->exporter('campaignion_manage');
+    return $exporter->columnOptions();
   }
-
 
   public function formElement(&$element, &$form_state) {
     $options = $this->getFields();
     $element['export'] = array(
-      '#type'     => 'checkboxes',
-      '#title'    => t('Select one or more fields that you want to export.'),
-      '#options'  => $options,
+      '#type' => 'checkboxes',
+      '#title' => t('Select one or more fields that you want to export.'),
+      '#options' => $options,
       '#default_value' => array_keys($options),
     );
   }
 
   public function apply($resultset, $values) {
-    $fields = array();
-    foreach ($this->getFields() as $field_name => $label) {
-      if (isset($values['export'][$field_name]) && $values['export'][$field_name]) {
-        $fields[$field_name] = $label;
-      }
-    }
-    $data['fields'] = $fields;
+    $data['fields'] = array_filter($values['export']);
     $data['csv_name'] = tempnam(file_directory_temp(), 'CampaignionSupporterExport_' );
     $this->initBatch($data);
     $messages = array(
@@ -60,28 +46,15 @@ class SupporterExport implements BatchInterface {
     return new SupporterExportBatch($data);
   }
 
+  /**
+   * Create the temporary file and add the header lines.
+   */
   protected function initBatch(&$data) {
-    // create the CSV column header line
-    $address_mapping = array(
-      'street'  => 'thoroughfare',
-      'country' => 'country',
-      'zip'     => 'postal_code',
-      'city'    => 'locality',
-      'region'  => 'administrative_area',
-    );
-    $csv_header = array();
-    foreach ($data['fields'] as $key => $value) {
-      if ($key === 'field_address') {
-        foreach ($address_mapping as $mapped_key => $key) {
-          $csv_header[$mapped_key] = $mapped_key;
-        }
-      }
-      else {
-        $csv_header[$key] = $value;
-      }
-    }
+    $exporter = ContactTypeManager::instance()->exporter('campaignion_manage');
+    $exporter->filterColumns($data['fields']);
     $handle = fopen($data['csv_name'], 'w');
-    fputcsv($handle, $csv_header);
+    fputcsv($handle, $exporter->header(0));
+    fputcsv($handle, $exporter->header(1));
     fclose($handle);
   }
 

--- a/campaignion_manage/src/BulkOp/SupporterExportBatch.php
+++ b/campaignion_manage/src/BulkOp/SupporterExportBatch.php
@@ -15,6 +15,7 @@ class SupporterExportBatch extends BatchBase {
     $this->filename = $data['csv_name'];
     $this->exporter = ContactTypeManager::instance()
       ->exporter('campaignion_manage');
+    $this->exporter->filterColumns($data['fields']);
   }
 
   public function start(&$context) {
@@ -26,20 +27,7 @@ class SupporterExportBatch extends BatchBase {
 
   public function apply($contact, &$result) {
     $this->exporter->setContact($contact);
-    $csv_line = array();
-    foreach ($this->fields as $field_name => $field_label) {
-      $value = $this->exporter->value($field_name);
-      if (is_array($value)) {
-        if (empty($value)) {
-          $value = array($field_name => '');
-        }
-      }
-      else {
-        $value = array($field_name => $value);
-      }
-      $csv_line += $value;
-    }
-    fputcsv($this->file, $csv_line);
+    fputcsv($this->file, $this->exporter->row());
   }
 
   public function commit() {

--- a/campaignion_manage/src/BulkOp/SupporterExportBatch.php
+++ b/campaignion_manage/src/BulkOp/SupporterExportBatch.php
@@ -13,8 +13,7 @@ class SupporterExportBatch extends BatchBase {
   public function __construct(&$data) {
     $this->fields = $data['fields'];
     $this->filename = $data['csv_name'];
-    $this->exporter = ContactTypeManager::instance()
-      ->exporter('campaignion_manage');
+    $this->exporter = ContactTypeManager::instance()->exporter('csv');
     $this->exporter->filterColumns($data['fields']);
   }
 

--- a/campaignion_mp_fields/src/MPDataLoader.php
+++ b/campaignion_mp_fields/src/MPDataLoader.php
@@ -137,7 +137,7 @@ class MPDataLoader {
    *   one.
    */
   protected function extractPostcode(array $item) {
-    if ($item['postal_code'] && $item['country'] == 'GB') {
+    if (!empty($item['postal_code']) && !empty($item['country']) && $item['country'] == 'GB') {
       $r = postal_code_validation_validate($item['postal_code'], 'GB');
       if (empty($r['error'])) {
         // Strip spaces and dashes allowed by postal_code_validation_validate().

--- a/src/CRM/CsvExporter.php
+++ b/src/CRM/CsvExporter.php
@@ -8,6 +8,31 @@ namespace Drupal\campaignion\CRM;
 class CsvExporter extends ExporterBase {
 
   /**
+   * Get an options array for choosing which columns of the CSV to display.
+   *
+   * @return string[]
+   *   Array of column labels keyed by column keys.
+   */
+  public function columnOptions() {
+    $options = [];
+    foreach ($this->map as $k => $l) {
+      list($h0, $h1) = [$l->header(0), $l->header(1)];
+      $options[$k] = $h1 ? "$h0 ($h1)" : $h0;
+    }
+    return $options;
+  }
+
+  /**
+   * Remove all columns from the map that are not in $fields.
+   *
+   * @param array $fields
+   *   Associative array with keys matching a selection of column keys.
+   */
+  public function filterColumns(array $fields) {
+    $this->map = isset($fields) ? array_intersect_key($this->map, $fields) : $this->map;
+  }
+
+  /**
    * Get header row.
    *
    * @param int $row_num

--- a/test/CRM/CsvExporterTest.php
+++ b/test/CRM/CsvExporterTest.php
@@ -66,4 +66,35 @@ class CsvExporterTest extends \DrupalUnitTestCase {
     ], $exporter->row());
   }
 
+  /**
+   * Test exporting a single contact and the headers.
+   */
+  public function testExportOneContactFiltered() {
+    $labels = new LabelFactory('redhen_contact', 'contact');
+    $address = $labels->fromExporter(new WrapperField('field_address'));
+
+    $map['contact_id']                 = new Label('Contact ID', new SingleValueField('contact_id'));
+    $map['field_address.thoroughfare'] = new SubField($address, 'thoroughfare', 'Address line 1');
+    $exporter = new CsvExporter($map);
+
+    $this->assertEqual([
+      'contact_id' => 'Contact ID',
+      'field_address.thoroughfare' => 'Address (Address line 1)',
+    ], $exporter->columnOptions());
+
+    $filter['contact_id'] = 'contact_id';
+    $exporter->filterColumns($filter);
+
+    $this->assertEqual([
+      'contact_id' => 'Contact ID',
+    ], $exporter->header(0));
+    $this->assertEqual([
+      'contact_id' => '',
+    ], $exporter->header(1));
+    $exporter->setContact($this->contact);
+    $this->assertEqual([
+      'contact_id' => $this->contact->contact_id,
+    ], $exporter->row());
+  }
+
 }


### PR DESCRIPTION
- Extend CsvExporter with functionality needed to select columns.
- Remove the custom and partially hard-coded column logic from the `campaignion_manage` bulk operation.
- Make the output between `campaignion_manage` and `campaignion_csv` consistent.

This also switches from the `'campaignion_manage'` to the `'csv'` exporter in order to ease migration. (The `SupporterExport` code now expects a `CsvExporter` instance.)