### PR TITLE
Fix: urlencode dataset keys before issuing requests.

### DIFF
--- a/campaignion_email_to_target/src/Api/Client.php
+++ b/campaignion_email_to_target/src/Api/Client.php
@@ -102,7 +102,7 @@ class Client extends _Client {
    */
   public function getDataset($key) {
     if (!array_key_exists($key, $this->datasets)) {
-      $this->datasets[$key] = Dataset::fromArray($this->get($key));
+      $this->datasets[$key] = Dataset::fromArray($this->get(urlencode($key)));
     }
     return $this->datasets[$key];
   }
@@ -121,7 +121,8 @@ class Client extends _Client {
    */
   public function getTargets($dataset_key, array $selector) {
     try {
-      return $this->get("$dataset_key/select", $selector);
+      $key = urlencode($dataset_key);
+      return $this->get("$key/select", $selector);
     }
     catch (HttpError $e) {
       if (in_array($e->getCode(), [400, 404])) {


### PR DESCRIPTION
This has lead to 401 errors as the e2t-api calculates the MAC for Hawk using the urlencoded path, while campaignion_email_to_target uses the unencoded path.