### PR TITLE
Opt-in: Empty radio default value must be an empty string.

### DIFF
--- a/campaignion_opt_in/campaignion_opt_in.component.inc
+++ b/campaignion_opt_in/campaignion_opt_in.component.inc
@@ -197,7 +197,7 @@ function _webform_render_opt_in($component, $value = NULL, $filter = TRUE) {
       $options = [Values::OPT_IN => $l[1], $no_value => $l[0]];
       $element += [
         '#type' => 'radios',
-        '#default_value' => isset($options[$value]) ? $value : FALSE,
+        '#default_value' => isset($options[$value]) ? $value : '',
         '#options' => $options,
       ];
   }


### PR DESCRIPTION
The value of a radio must either be an empty string or a key defined in `#options` otherwise an error is logged. See `_webform_client_form_validate()`.