### PR TITLE
Disable menu links for creating new email protests.

### DIFF
--- a/campaignion_email_protest/campaignion_email_protest.module
+++ b/campaignion_email_protest/campaignion_email_protest.module
@@ -142,3 +142,19 @@ function campaignion_email_protest_form_builder_element_types_alter(&$types, $fo
     $types['protest_target']['addable'] = TRUE;
   }
 }
+
+/**
+ * Implements hook_menu_alter().
+ *
+ * Disable menu links for creating new email protest nodes.
+ * Campaignion_email_to_target should be used instead.
+ */
+function campaignion_email_protest_menu_alter(&$items) {
+  $loader = Loader::instance();
+  foreach ($loader->allTypes() as $type_name => $type) {
+    if ($type->isEmailProtest()) {
+      $url_type = str_replace('_', '-', $type_name);
+      $items["wizard/$url_type"]['access callback'] = FALSE;
+    }
+  }
+}


### PR DESCRIPTION
`campaignion_email_protest` is deprecated, `campaignion_email_to_target` should be used instead. For a smooth transition, users should not be able to still add new nodes of the old content type.