### PR TITLE
Add NewsletterList::options() and use it where possible.

### DIFF
--- a/campaignion_manage/src/BulkOp/SupporterNewsletter.php
+++ b/campaignion_manage/src/BulkOp/SupporterNewsletter.php
@@ -2,7 +2,8 @@
 
 namespace Drupal\campaignion_manage\BulkOp;
 
-use \Drupal\campaignion_manage\BatchJob;
+use Drupal\campaignion_manage\BatchJob;
+use Drupal\campaignion_newsletters\NewsletterList;
 
 class SupporterNewsletter implements BatchInterface {
   public function title() {
@@ -14,14 +15,10 @@ class SupporterNewsletter implements BatchInterface {
   }
 
   public function formElement(&$element, &$form_state) {
-    $options = array();
-    foreach (\Drupal\campaignion_newsletters\NewsletterList::listAll() as $list) {
-      $options[$list->list_id] = $list->title;
-    }
     $element['lists'] = array(
       '#type'    => 'checkboxes',
       '#title'   => t('Select one or lists'),
-      '#options' => $options,
+      '#options' => NewsletterList::options(),
     );
   }
 

--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -82,7 +82,7 @@ function campaignion_newsletters_webform_submission_confirmed(Submission $submis
   if (!($email = $s->value('email'))) {
     return;
   }
-  $subscriptions = new Subscriptions(NewsletterList::listAll(), [$email], []);
+  $subscriptions = new Subscriptions(NewsletterList::options(), [$email], []);
   foreach ($s->webform->componentsByType('opt_in') as $component) {
     if ($component['extra']['channel'] == 'email') {
       $subscriptions->merge(Component::fromComponent($component)->getSubscriptions($email, $s));

--- a/campaignion_newsletters/src/Component.php
+++ b/campaignion_newsletters/src/Component.php
@@ -159,8 +159,8 @@ class Component {
   public function getAllListIds() {
     if (is_null($this->allListIds)) {
       $list_ids = [];
-      foreach (NewsletterList::listAll() as $l) {
-        $list_ids[] = $l->list_id;
+      foreach (array_keys(NewsletterList::options()) as $list_id) {
+        $list_ids[] = $list_id;
       }
       $this->setAllListIds($list_ids);
     }

--- a/campaignion_newsletters/src/NewsletterList.php
+++ b/campaignion_newsletters/src/NewsletterList.php
@@ -38,6 +38,21 @@ class NewsletterList extends Model {
   }
 
   /**
+   * Get a sorted array of all list titles keyed by list ID.
+   */
+  public static function options() {
+    $result = db_select(static::$table, 'l')
+      ->fields('l', ['list_id', 'title'])
+      ->orderBy('l.title')
+      ->execute();
+    $options = [];
+    foreach ($result as $row) {
+      $options[$row->list_id] = $row->title;
+    }
+    return $options;
+  }
+
+  /**
    * Generic function to load using conditions and order criteria.
    */
   protected static function loadQuery($conditions = [], $order_by = []) {

--- a/campaignion_newsletters/src/Subscriptions.php
+++ b/campaignion_newsletters/src/Subscriptions.php
@@ -40,8 +40,8 @@ class Subscriptions {
   /**
    * Construct a new subscription matrix.
    *
-   * @param \Drupal\campaignion_newsletters\NewsletterList[] $lists
-   *   Array of all available newsletter lists.
+   * @param string[] $lists
+   *   Associative array of all list titles keyed by list ID.
    * @param string[] $addresses
    *   Array of email addresses that may be subscribed.
    * @param \Drupal\campaignion_newsletters\Subscription[] $stored_subscriptions
@@ -51,7 +51,7 @@ class Subscriptions {
     $subscriptions = array();
     foreach ($addresses as $email) {
       $subscriptions[$email] = array();
-      foreach ($lists as $list_id => $list) {
+      foreach (array_keys($lists) as $list_id) {
         $subscriptions[$email][$list_id] = NULL;
       }
     }
@@ -65,12 +65,12 @@ class Subscriptions {
   /**
    * Get an array of all newsletter lists.
    *
-   * @return \Drupal\campaignion_newsletters\NewsletterList[]
-   *   All currently known newsletter lists.
+   * @return string[]
+   *   Associative array of all list titles keyed by list ID.
    */
   public static function lists() {
     if (!isset(static::$lists)) {
-      static::$lists = NewsletterList::listAll();
+      static::$lists = NewsletterList::options();
     }
     return static::$lists;
   }


### PR DESCRIPTION
`NewsletterList::listAll()` might cause a spike in memory usage for installations with many lists (≥1000). It’s better to avoid its use if possible.