### PR TITLE
Fix setting created timestamp on Contact.

### DIFF
--- a/src/Contact.php
+++ b/src/Contact.php
@@ -18,7 +18,7 @@ class Contact extends \RedhenContact {
     if (!$this->type) {
       $this->type = static::defaultType();
     }
-    if (!$this->created) {
+    if (!isset($this->created)) {
       $this->created = REQUEST_TIME;
     }
     // Make sure all fields are represented as properties on the object.

--- a/test/ContactTest.php
+++ b/test/ContactTest.php
@@ -52,4 +52,12 @@ class ContactTest extends \DrupalUnitTestCase {
     $this->assertEmpty($stored_contact->wrap()->field_title->value());
   }
 
+  /**
+   * Test zero creation time is left as is.
+   */
+  public function testZeroCreationTime() {
+    $contact = new Contact(['created' => 0]);
+    $this->assertEqual(0, $contact->created);
+  }
+
 }


### PR DESCRIPTION
- we want it to be set when the Contact is new/created
- but if the Contact exists and the value in the DB (for whatever
  reason) *is* 0, then it should return 0