### PR TITLE
Use distinct alter hook for e2t redirects.

### DIFF
--- a/campaignion_action/campaignion_action.module
+++ b/campaignion_action/campaignion_action.module
@@ -197,7 +197,20 @@ function campaignion_action_webform_redirect_alter(FormRedirect &$redirect, Subm
       $redirect = FormRedirect::fromFormStateRedirect($action_redirect);
     }
   }
+  _campaignion_action_redirect_add_get_parameters($redirect, $submission);
+}
 
+/**
+ * Implements hook_campaignion_email_to_target_redirect_alter().
+ */
+function campaignion_action_campaignion_email_to_target_redirect_alter(FormRedirect &$redirect, Submission $submission) {
+  _campaignion_action_redirect_add_get_parameters($redirect, $submission);
+}
+
+/**
+ * Helper function to add the share and sid parameter to a redirect.
+ */
+function _campaignion_action_redirect_add_get_parameters(FormRedirect &$redirect, Submission $submission) {
   $action_path = 'node/' . $submission->nid;
   $redirect->query['share'] = $action_path;
   $redirect->query['sid'] = $submission->sid;

--- a/campaignion_email_to_target/campaignion_email_to_target.api.php
+++ b/campaignion_email_to_target/campaignion_email_to_target.api.php
@@ -7,6 +7,9 @@
  * This file does not contain actually executed code.
  */
 
+use Drupal\little_helpers\System\FormRedirect;
+use Drupal\little_helpers\Webform\Submission;
+
 /**
  * Declare selection mode plugins.
  *
@@ -22,4 +25,19 @@ function hook_campaignion_email_to_target_selection_modes() {
     'title' => t('Some special way of selecting targets.'),
   ];
   return $plugins;
+}
+
+/**
+ * Alter exclusion redirects.
+ *
+ * When an exclusion matches and it’s configured to redirect other modules can
+ * manipulate the redirect destination using this hook.
+ *
+ * @param \Drupal\little_helpers\System\FormRedirect $redirect
+ *   The redirect to be altered.
+ * @param \Drupal\little_helpers\Webform\Submission $submission
+ *   The submission that is about to be finished.
+ */
+function hook_campaignion_email_to_target_redirect_alter(FormRedirect &$redirect, Submission $submission) {
+  $redirect->query['utm_source'] = 'my-tracking-parameter';
 }

--- a/campaignion_email_to_target/src/Component.php
+++ b/campaignion_email_to_target/src/Component.php
@@ -148,7 +148,7 @@ class Component {
       $this->disableSubmits($form);
       if ($redirect = $exclusion->redirect()) {
         $submission = $this->saveSubmission($form, $form_state);
-        drupal_alter('webform_redirect', $redirect, $submission);
+        drupal_alter('campaignion_email_to_target_redirect', $redirect, $submission);
         $this->redirect($redirect, $form, $form_state);
       }
       return;

--- a/campaignion_webform_tokens/campaignion_webform_tokens.module
+++ b/campaignion_webform_tokens/campaignion_webform_tokens.module
@@ -53,6 +53,13 @@ function campaignion_webform_tokens_webform_redirect_alter(FormRedirect &$redire
 }
 
 /**
+ * Implements hook_campaignion_email_to_target_redirect_alter().
+ */
+function campaignion_webform_tokens_campaignion_email_to_target_redirect_alter(FormRedirect &$redirect, Submission $submission) {
+  campaignion_webform_tokens_webform_redirect_alter($redirect, $submission);
+}
+
+/**
  * Returns a safe HMAC value for a submission ID used for authentication.
  *
  * @param int $sid


### PR DESCRIPTION
`hook_webform_redirect()` is intended to be only called when a submission is finished or confirmed. Calling it when redirecting because of a e2t exclusion was a rather weird choice. We still want to keep most of the GET-parameters though.

This PR changes e2t so that it calls a more specific `hook_campaignion_email_to_target_redirect_alter()` with the same signature.