### PR TITLE
Remove the specific permission for viewing email to target messages.

### DIFF
--- a/campaignion_email_to_target/campaignion_email_to_target.module
+++ b/campaignion_email_to_target/campaignion_email_to_target.module
@@ -26,17 +26,6 @@ use \Drupal\campaignion_email_to_target\SelectionMode\One;
 use \Drupal\campaignion_email_to_target\SelectionMode\OneOrMore;
 
 /**
- * Implements hook_permission().
- */
-function campaignion_email_to_target_permission() {
-  $p['view email_to_target messages'] = [
-    'title' => t('View Email-to-target messages'),
-    'description' => t('View and export the contents of messages sent to targets.'),
-  ];
-  return $p;
-}
-
-/**
  * Implements hook_menu().
  */
 function campaignion_email_to_target_menu() {

--- a/campaignion_email_to_target/webform.php
+++ b/campaignion_email_to_target/webform.php
@@ -117,7 +117,7 @@ function _webform_show_single_target_e2t_selector($nid) {
  * Implements _webform_csv_headers_component().
  */
 function _webform_csv_headers_e2t_selector($component, $export_options) {
-  $multi_column = user_access('view email_to_target messages') && _webform_show_single_target_e2t_selector($component['nid']);
+  $multi_column = _webform_show_single_target_e2t_selector($component['nid']);
   if ($multi_column) {
     $header = [
       ['', '', '', '', '', '', ''],
@@ -146,9 +146,6 @@ function _webform_csv_headers_e2t_selector($component, $export_options) {
  * Implements _webform_csv_data_component().
  */
 function _webform_csv_data_e2t_selector($component, $export_options, $value) {
-  if (!user_access('view email_to_target messages')) {
-    return t('No permission to view email to target messages.');
-  }
   if (_webform_show_single_target_e2t_selector($component['nid'])) {
     // Three columns: To, Subject, Message
     if (!empty($value[0])) {


### PR DESCRIPTION
Rationale:
1. In Drupal 7 cron is always executed as anonymous.
2. The CSV exports done in cron-jobs must be able to read all data.
3. No other webform components seem to restrict viewing of submitted data.
4. This wasn’t implemented thoroughly: Neither display (submission details) nor the submission table did check for the permission.