### PR TITLE
[campaignion overlay] fix close button position

### DIFF
--- a/campaignion_overlay/campaignion_overlay.js
+++ b/campaignion_overlay/campaignion_overlay.js
@@ -26,7 +26,7 @@
         close.click(function() {
           overlay.dialog("close");
         });
-        overlay.find('.campaignion-overlay-content').prepend(close);
+        overlay.find('.campaignion-overlay-options').prepend(close);
 
         // generic class to use with e.g. custom buttons
         $('.campaignion-overlay-close', context).click(function(event) {


### PR DESCRIPTION
Render the close button on top of the dialog, not between introduction and content.