### PR TITLE
e2t: Avoid loading the e2t dataset to determine CSV columns.

### DIFF
--- a/campaignion_email_to_target/tests/WebformTest.php
+++ b/campaignion_email_to_target/tests/WebformTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\campaignion_email_to_target;
+
+use Drupal\campaignion_action\Loader;
+use Upal\DrupalUnitTestCase;
+
+use Drupal\campaignion_email_to_target\Api\Client;
+
+/**
+ * Test webform component callbacks.
+ */
+class WebformTest extends DrupalUnitTestCase {
+
+  /**
+   * Create test node.
+   */
+  public function setUp() {
+    parent::setUp();
+    $GLOBALS['conf']['campaignion_email_to_target_credentials'] = [
+      'url' => 'http://mocked',
+      'public_key' => 'pk',
+      'secret_key' => 'sk',
+    ];
+    $node = (object) [
+      'type' => 'email_to_target',
+    ];
+    node_object_prepare($node);
+    $node->field_email_to_target_options['und'][0] = [
+      'dataset_name' => 'mp',
+    ];
+    entity_save('node', $node);
+    $this->node = entity_load_single('node', $node->nid);
+  }
+
+  /**
+   * Delete test node.
+   */
+  public function tearDown() {
+    unset($GLOBALS['conf']['campaignion_email_to_target_credentials']);
+    entity_delete('node', $this->node->nid);
+    parent::tearDown();
+  }
+
+  /**
+   * Test getting CSV header for a MP dataset.
+   */
+  public function testMpColumns() {
+    $component['name'] = 'Component name';
+    $component['nid'] = $this->node->nid;
+    $cols = webform_component_invoke('e2t_selector', 'csv_headers', $component, []);
+    $this->assertEqual(['', '', '', '', '', '', ''], $cols[0]);
+    $this->assertEqual(['Component name', '', '', '', '', '', ''], $cols[1]);
+    $this->assertEqual([
+      'To',
+      'Subject',
+      'Message',
+      'Constituency',
+      'Target salutation',
+      'Party',
+      'Devolved country',
+    ], $cols[2]);
+  }
+
+  /**
+   * Test getting CSV header for a non-MP dataset.
+   */
+  public function testNonMpColumns() {
+    $this->node->field_email_to_target_options['und'][0]['dataset_name'] = 'other';
+    $component['name'] = 'Component name';
+    $component['nid'] = $this->node->nid;
+    $cols = webform_component_invoke('e2t_selector', 'csv_headers', $component, []);
+    $this->assertEqual('', $cols[0]);
+    $this->assertEqual('', $cols[1]);
+    $this->assertEqual('Component name', $cols[2]);
+  }
+
+}

--- a/campaignion_email_to_target/webform.php
+++ b/campaignion_email_to_target/webform.php
@@ -107,7 +107,7 @@ function _webform_show_single_target_e2t_selector($nid) {
   $return = FALSE;
   if (($node = node_load($nid)) && $node->type == 'email_to_target') {
     $action = Loader::instance()->actionFromNode($node);
-    $return = $action->dataset()->key == 'mp';
+    $return = $action->getOptions()['dataset_name'] == 'mp';
   }
   $static_cache[$nid] = $return;
   return $return;


### PR DESCRIPTION
This also solves issues with CSV exports where the exporter can’t be
used if an inaccessible dataset is selected.