### PR TITLE
e2t: Remove NullCacheBin when disabling the module.

### DIFF
--- a/campaignion_email_to_target/campaignion_email_to_target.install
+++ b/campaignion_email_to_target/campaignion_email_to_target.install
@@ -7,6 +7,7 @@
 
 use Drupal\campaignion_email_to_target\Api\Client;
 use Drupal\campaignion_email_to_target\Api\ConfigError;
+use Drupal\campaignion_email_to_target\NullCacheBin;
 
 /**
  * Implements hook_schema()
@@ -138,7 +139,16 @@ function campaignion_email_to_target_field_schema($field) {
  * Implements hook_enable().
  */
 function campaignion_email_to_target_enable() {
-  variable_set('cache_class_cache_token', '\\Drupal\\campaignion_email_to_target\\NullCacheBin');
+  variable_set('cache_class_cache_token', NullCacheBin::class);
+}
+
+/**
+ * Implements hook_disable().
+ */
+function campaignion_email_to_target_disable() {
+  if (variable_get('cache_class_cache_token') == NullCacheBin::class) {
+    variable_del('cache_class_cache_token');
+  }
 }
 
 /**


### PR DESCRIPTION
The problem was made visible with the latest little_helpers changes that deactivated autoloading modules from disabled/uninstalled modules.