### PR TITLE
[newsletters] Fix inconsistent variable names

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters.install
+++ b/campaignion_newsletters/campaignion_newsletters.install
@@ -196,6 +196,16 @@ function campaignion_newsletters_uninstall() {
 }
 
 /**
+ * Rename variable.
+ */
+function campaignion_newsletters_update_21() {
+  if ($old_value = variable_get_value('campaignion_newsletters_opt_out_unknown')) {
+    variable_set_value('campaignion_newsletters_unsubscribe_unknown', $old_value);
+  }
+  variable_del('campaignion_newsletters_opt_out_unknown');
+}
+
+/**
  * Migrate to using opt_in components.
  */
 function campaignion_newsletters_update_20() {

--- a/campaignion_newsletters/src/Component.php
+++ b/campaignion_newsletters/src/Component.php
@@ -38,7 +38,7 @@ class Component {
    *   Component array as stored in `$node->webform['components']`.
    */
   public static function fromComponent(array $component) {
-    $unsubscribe_unknown = variable_get_value('campaignion_newsletters_opt_out_unknown');
+    $unsubscribe_unknown = variable_get_value('campaignion_newsletters_unsubscribe_unknown');
     return new static($component, $unsubscribe_unknown);
   }
 


### PR DESCRIPTION
Alternatively, we could also change the variable read in [Component::fromComponent](https://github.com/moreonion/campaignion/blob/7.x-2.x/campaignion_newsletters/src/Component.php#L41) but this seems safer as it keeps the variable that’s potentially in use now (and working) unchanged.