### PR TITLE
[layout] Make layouts theme independent.

### DIFF
--- a/campaignion_layout/README.md
+++ b/campaignion_layout/README.md
@@ -1,0 +1,14 @@
+# Campaignion layouts
+
+This module enables themes to have different layout variations. It provides a field that can be added to nodes in order for the user to select which layout variation to use when displaying this node.
+
+
+## Available layouts
+
+In order for a layout to be active / or selectable the following conditions need to be met:
+
+- The layout must be **declared** by an enabled theme by implementing `hook_campaignion_layout_info()` (this special hook is invoked on all enabled themes, not modules).
+- The layout must be **implemented** by the theme by adding it to the `layout[]` property in its `.info`-file (and perhaps adjusting styles and templates). Themes inherit the `layout[]` property from their base themes.
+- The layout must be **enabled** for the theme in its theme settings.
+
+The form element on the node shows all layouts that are enabled on any enabled theme. It disables all options that are not currently available for the selected theme.

--- a/campaignion_layout/campaignion_layout.field.inc
+++ b/campaignion_layout/campaignion_layout.field.inc
@@ -93,8 +93,9 @@ function campaignion_layout_field_widget_form(&$form, &$form_state, $field, $ins
     '#id' => $html_id,
   ];
   $fields = [];
+  $available_layouts = array_intersect_key($themes->declaredLayouts(), $layout_available_in_theme);
   $options = ['' => t('Default layout')];
-  foreach ($themes->declaredLayouts() as $layout => $info) {
+  foreach ($available_layouts as $layout => $info) {
     $options[$layout] = $info['title'];
     foreach (array_keys(array_filter($info['fields'])) as $field_name) {
       $fields[$field_name]["#$html_id input"][] = $layout;

--- a/campaignion_layout/campaignion_layout.field.inc
+++ b/campaignion_layout/campaignion_layout.field.inc
@@ -48,13 +48,14 @@ function campaignion_layout_field_widget_form(&$form, &$form_state, $field, $ins
     'theme' => NULL,
     'layout' => '',
   ]);
-  $themes = Container::get()->loadService('campaignion_layout.themes')->enabledThemes();
-  $selected_theme = isset($themes[$item['theme']]) ? $item['theme'] : NULL;
+  $themes = Container::get()->loadService('campaignion_layout.themes');
+  $enabled_themes = $themes->enabledThemes();
+  $selected_theme = isset($enabled_themes[$item['theme']]) ? $item['theme'] : NULL;
   $toggle_id = drupal_html_id('layout_toggle');
   $element['enabled'] = [
     '#type' => 'checkbox',
     '#title' => t('Custom theme and layout.'),
-    '#default_value' => $themes && $selected_theme,
+    '#default_value' => $enabled_themes && $selected_theme,
     '#id' => $toggle_id,
   ];
   $toggle_states['visible']["#$toggle_id"]['checked'] = TRUE;
@@ -67,7 +68,7 @@ function campaignion_layout_field_widget_form(&$form, &$form_state, $field, $ins
 
   $theme_options = array_map(function ($theme) {
     return $theme->title();
-  }, $themes);
+  }, $enabled_themes);
   $theme_id = drupal_html_id('campaignion-layout-theme');
   $element['values']['theme'] = [
     '#type' => 'select',
@@ -77,37 +78,38 @@ function campaignion_layout_field_widget_form(&$form, &$form_state, $field, $ins
     '#default_value' => $selected_theme,
     '#id' => $theme_id,
   ];
+  $layout_available_in_theme = [];
+  foreach ($enabled_themes as $theme_name => $theme) {
+    foreach (array_keys($theme->layouts()) as $layout) {
+      $layout_available_in_theme[$layout][$theme_name] = $theme_name;
+    }
+  }
+
+  $html_id = drupal_html_id('campaignion-layout_layout');
   $element['values']['layout'] = [
-    '#type' => 'value',
-    '#value' => $item['layout'],
+    '#type' => 'radios',
+    '#title' => t('Layout'),
+    '#description' => t('This layout is used for displaying the content.'),
+    '#id' => $html_id,
   ];
   $fields = [];
-  foreach ($themes as $theme_name => $theme) {
-    $options = ['' => t('Default layout')];
-    $html_id = drupal_html_id("layout_{$theme_name}");
-    foreach ($theme->layouts() as $layout => $info) {
-      $options[$layout] = $info['title'];
-      foreach (array_keys(array_filter($info['fields'])) as $field_name) {
-        $fields[$field_name]["#$html_id input"][] = $layout;
-      }
+  $options = ['' => t('Default layout')];
+  foreach ($themes->declaredLayouts() as $layout => $info) {
+    $options[$layout] = $info['title'];
+    foreach (array_keys(array_filter($info['fields'])) as $field_name) {
+      $fields[$field_name]["#$html_id input"][] = $layout;
     }
-    $states['visible']["#{$theme_id}"]['value'] = $theme_name;
-    $selected_layout = '';
-    if ($theme_name == $selected_theme && isset($options[$item['layout']])) {
-      $selected_layout = $item['layout'];
+    $element['values']['layout'][$layout]['#disabled'] = TRUE;
+    foreach ($layout_available_in_theme[$layout] ?? [] as $theme_name) {
+      $element['values']['layout'][$layout]['#states']['enabled']["#$theme_id"][]['value'] = $theme_name;
     }
-    $element['values']["layout_{$theme_name}"] = [
-      '#type' => 'radios',
-      '#title' => t('Layout'),
-      '#description' => t('This layout is used for displaying the content.'),
-      '#options' => $options,
-      '#default_value' => $selected_layout,
-      '#states' => $states,
-      '#id' => $html_id,
-    ];
   }
+  $element['values']['layout'] += [
+    '#options' => $options,
+    '#default_value' => isset($options[$item['layout']]) ? $item['layout'] : '',
+  ];
   $form_state['campaignion_layout_fields'] = $fields;
-  if (!$themes) {
+  if (!$enabled_themes) {
     $element['#access'] = FALSE;
   }
   return $element;
@@ -123,7 +125,7 @@ function _campaignion_layout_field_widget_validate($element, &$form_state, $form
   ];
   if ($element['enabled']['#value']) {
     $values['theme'] = $element['values']['theme']['#value'];
-    $values['layout'] = $element['values']["layout_{$values['theme']}"]['#value'];
+    $values['layout'] = $element['values']['layout']['#value'];
   }
   form_set_value($element, $values, $form_state);
 }

--- a/campaignion_layout/campaignion_layout.field.inc
+++ b/campaignion_layout/campaignion_layout.field.inc
@@ -76,7 +76,6 @@ function campaignion_layout_field_widget_form(&$form, &$form_state, $field, $ins
     '#options' => $theme_options,
     '#default_value' => $selected_theme,
     '#id' => $theme_id,
-    '#states' => $toggle_states,
   ];
   $element['values']['layout'] = [
     '#type' => 'value',
@@ -103,7 +102,7 @@ function campaignion_layout_field_widget_form(&$form, &$form_state, $field, $ins
       '#description' => t('This layout is used for displaying the content.'),
       '#options' => $options,
       '#default_value' => $selected_layout,
-      '#states' => $states + $toggle_states,
+      '#states' => $states,
       '#id' => $html_id,
     ];
   }

--- a/campaignion_layout/src/Themes.php
+++ b/campaignion_layout/src/Themes.php
@@ -90,4 +90,16 @@ class Themes {
     return $info;
   }
 
+  /**
+   * Get declared layouts for as an #options-array.
+   *
+   * @return string[]
+   *   Machine name as key mapped to the translated title for each layouts.
+   */
+  public function layoutOptions() {
+    return array_map(function (array $info) {
+      return $info['title'];
+    }, $this->declaredLayouts());
+  }
+
 }

--- a/campaignion_layout/src/Themes.php
+++ b/campaignion_layout/src/Themes.php
@@ -36,7 +36,7 @@ class Themes {
   public function getTheme($theme_name) {
     if ($theme = $this->themes[$theme_name] ?? NULL) {
       $base = isset($theme->base_theme) ? $this->getTheme($theme->base_theme) : NULL;
-      return new Theme($theme, $base);
+      return new Theme($theme, $this, $base);
     }
   }
 
@@ -51,6 +51,26 @@ class Themes {
     return array_filter($all_themes, function ($theme) {
       return $theme->isEnabled();
     });
+  }
+
+  /**
+   * Get all declared layouts.
+   */
+  public function declaredLayouts() {
+    $info = [];
+    foreach ($this->enabledThemes() as $theme) {
+      $info = drupal_array_merge_deep($info, $theme->invokeLayoutHook());
+    }
+    foreach ($info as $name => &$i) {
+      $i += ['name' => $name, 'fields' => []];
+      foreach ($i['fields'] as $field_name => &$f) {
+        $f += [
+          'display' => [],
+          'variable' => $field_name,
+        ];
+      }
+    }
+    return $info;
   }
 
 }

--- a/campaignion_layout/src/Themes.php
+++ b/campaignion_layout/src/Themes.php
@@ -40,8 +40,16 @@ class Themes {
 
   /**
    * Create instance for a single theme.
+   *
+   * @param string $theme_name
+   *   The machine name of the theme to be loaded. If no value is passed the
+   *   currently active theme is loaded.
+   *
+   * @return \Drupal\campaignion_layout\Theme|null
+   *   The requested theme or NULL if it isn’t found.
    */
-  public function getTheme($theme_name) {
+  public function getTheme(string $theme_name = NULL) {
+    $theme_name = $theme_name ?? $GLOBALS['theme'];
     if ($theme = $this->themes[$theme_name] ?? NULL) {
       $base = isset($theme->base_theme) ? $this->getTheme($theme->base_theme) : NULL;
       return new Theme($theme, $this, $base);

--- a/campaignion_layout/tests/FieldTest.php
+++ b/campaignion_layout/tests/FieldTest.php
@@ -85,23 +85,22 @@ class FieldTest extends DrupalUnitTestCase {
       'b' => 'Theme B',
     ], $element['values']['theme']['#options']);
     $this->assertNull($element['values']['theme']['#default_value']);
-    $this->assertNotEmpty($element['values']['layout_a']['#options']);
+    $this->assertNotEmpty($element['values']['layout']['#options']);
     $this->assertEqual([
       '' => 'Default layout',
       '2col' => 'Two columns',
       'banner' => 'Banner',
-    ], $element['values']['layout_a']['#options']);
-    $this->assertEqual('', $element['values']['layout_a']['#default_value']);
-    $this->assertNotEmpty($element['values']['layout_b']['#options']);
+      '1col' => 'Single column',
+    ], $element['values']['layout']['#options']);
+    $this->assertEqual('', $element['values']['layout']['#default_value']);
     $this->assertEqual([
-      'banner' => ['#layout-a input' => ['banner']],
+      'banner' => ['#campaignion-layout-layout input' => ['banner']],
     ], $form_state['campaignion_layout_fields']);
 
     $element['#parents'] = [];
     $element['enabled']['#value'] = TRUE;
     $element['values']['theme']['#value'] = 'a';
-    $element['values']['layout_a']['#value'] = 'banner';
-    $element['values']['layout_b']['#value'] = '1col';
+    $element['values']['layout']['#value'] = 'banner';
     $form_state['values'] = [];
     _campaignion_layout_field_widget_validate($element, $form_state, $form);
     $this->assertEqual('banner', $form_state['values']['layout']);
@@ -124,8 +123,7 @@ class FieldTest extends DrupalUnitTestCase {
     $element = campaignion_layout_field_widget_form($form, $form_state, NULL, NULL, NULL, $items, 0, []);
     $this->assertFalse($element['enabled']['#default_value']);
     $this->assertNull($element['values']['theme']['#default_value']);
-    $this->assertEqual('', $element['values']['layout_a']['#default_value']);
-    $this->assertEqual('', $element['values']['layout_b']['#default_value']);
+    $this->assertEqual('2col', $element['values']['layout']['#default_value']);
   }
 
   /**
@@ -139,8 +137,7 @@ class FieldTest extends DrupalUnitTestCase {
     $element = campaignion_layout_field_widget_form($form, $form_state, NULL, NULL, NULL, $items, 0, []);
     $this->assertTrue($element['enabled']['#default_value']);
     $this->assertEqual('a', $element['values']['theme']['#default_value']);
-    $this->assertEqual('', $element['values']['layout_a']['#default_value']);
-    $this->assertEqual('', $element['values']['layout_b']['#default_value']);
+    $this->assertEqual('', $element['values']['layout']['#default_value']);
   }
 
   /**
@@ -154,8 +151,7 @@ class FieldTest extends DrupalUnitTestCase {
     $element = campaignion_layout_field_widget_form($form, $form_state, NULL, NULL, NULL, $items, 0, []);
     $this->assertTrue($element['enabled']['#default_value']);
     $this->assertEqual('a', $element['values']['theme']['#default_value']);
-    $this->assertEqual('2col', $element['values']['layout_a']['#default_value']);
-    $this->assertEqual('', $element['values']['layout_b']['#default_value']);
+    $this->assertEqual('2col', $element['values']['layout']['#default_value']);
   }
 
   /**

--- a/campaignion_layout/tests/FieldTest.php
+++ b/campaignion_layout/tests/FieldTest.php
@@ -24,7 +24,6 @@ class FieldTest extends DrupalUnitTestCase {
    */
   protected function injectThemes($themes = [], $layouts = []) {
     $theme_objects = [];
-    $layouts = [];
     $add_layout_defaults = function ($info) {
       return $info + ['fields' => []];
     };
@@ -75,7 +74,8 @@ class FieldTest extends DrupalUnitTestCase {
    * Test rendering the field widget with themes.
    */
   public function testFieldWidgetWithThemes() {
-    $this->injectThemes($this->twoThemes());
+    $extra_layouts['extra']['title'] = 'Extra layout not available in any theme';
+    $this->injectThemes($this->twoThemes(), $extra_layouts);
     $form = [];
     $form_state = [];
     $element = campaignion_layout_field_widget_form($form, $form_state, NULL, NULL, NULL, [], 0, []);

--- a/campaignion_layout/tests/ThemeTest.php
+++ b/campaignion_layout/tests/ThemeTest.php
@@ -14,13 +14,13 @@ class ThemeTest extends DrupalUnitTestCase {
    */
   public function testHasFeature() {
     $data = (object) ['info' => ['features' => ['foo', 'bar']]];
-    $theme = new Theme($data);
+    $theme = new Theme($data, $this->createMock(Themes::class));
     $this->assertFalse($theme->hasFeature());
 
     $data = (object) [
       'info' => ['features' => ['foo', 'layout_variations', 'baz']],
     ];
-    $theme = new Theme($data);
+    $theme = new Theme($data, $this->createMock(Themes::class));
     $this->assertTrue($theme->hasFeature());
   }
 
@@ -33,11 +33,13 @@ class ThemeTest extends DrupalUnitTestCase {
 
     $theme = $mock_builder->setConstructorArgs([
       (object) ['status' => 0],
+      $this->createMock(Themes::class),
     ])->getMock();
     $this->assertFalse($theme->isEnabled());
 
     $theme = $mock_builder->setConstructorArgs([
       (object) ['status' => 1],
+      $this->createMock(Themes::class),
     ])->getMock();
     $this->assertFalse($theme->isEnabled());
 
@@ -52,7 +54,7 @@ class ThemeTest extends DrupalUnitTestCase {
    * Test checking for the active theme.
    */
   public function testIsActive() {
-    $theme = new Theme((object) ['name' => 'foo']);
+    $theme = new Theme((object) ['name' => 'foo'], $this->createMock(Themes::class));
 
     $this->assertTrue($theme->isActive('foo'));
     $this->assertFalse($theme->isActive('bar'));
@@ -63,34 +65,61 @@ class ThemeTest extends DrupalUnitTestCase {
    */
   public function testLayoutOptions() {
     $mock_builder = $this->getMockBuilder(Theme::class)
-      ->setMethods(['setting', 'invokeLayoutHook']);
+      ->setMethods(['setting']);
+    $mock_themes = $this->createMock(Themes::class);
+    $mock_themes->method('declaredLayouts')->willReturn([
+      'foo' => ['name' => 'foo', 'title' => 'Foo', 'fields' => []],
+      'bar' => ['name' => 'bar', 'title' => 'Bar', 'fields' => []],
+      'baz' => ['name' => 'baz', 'title' => 'Baz', 'fields' => []],
+    ]);
 
     $theme = $mock_builder->setConstructorArgs([
-      (object) ['status' => 1, 'name' => 'foo'],
+      (object) [
+        'status' => 1,
+        'name' => 'foo',
+        'info' => [
+          'layout' => ['foo', 'baz'],
+        ],
+      ],
+      $mock_themes,
     ])->getMock();
-    $theme->method('invokeLayoutHook')->willReturn([
-      'foo' => ['title' => 'Foo'],
-      'bar' => ['title' => 'Bar'],
-      'baz' => ['title' => 'Baz'],
-    ]);
     // No setting yet → No layouts activated.
     $this->assertEqual([], $theme->layoutOptions());
 
-    // Activate the bar-layout.
+    // Activate the bar-layout and baz-layout although bar is not implemented.
     $theme->method('setting')->willReturn([
+      'foo' => 0,
       'bar' => 'bar',
-      'baz' => 0,
+      'baz' => 'baz',
     ]);
     $this->assertEqual([
-      'bar' => 'Bar',
+      'baz' => 'Baz',
     ], $theme->layoutOptions());
 
-    // List the entire layout info with defaults added.
+    // List all implemented layouts.
+    $this->assertEqual([
+      'foo' => ['name' => 'foo', 'title' => 'Foo', 'fields' => []],
+      'baz' => ['name' => 'baz', 'title' => 'Baz', 'fields' => []],
+    ], $theme->layouts(TRUE));
+
+    // Test child theme inheritance.
+    $child_theme = $mock_builder->setConstructorArgs([
+      (object) [
+        'status' => 1,
+        'name' => 'foo',
+        'info' => [
+          'layout' => ['bar'],
+        ],
+      ],
+      $mock_themes,
+      $theme,
+    ])->getMock();
+    // List all implemented layouts in the child theme.
     $this->assertEqual([
       'foo' => ['name' => 'foo', 'title' => 'Foo', 'fields' => []],
       'bar' => ['name' => 'bar', 'title' => 'Bar', 'fields' => []],
       'baz' => ['name' => 'baz', 'title' => 'Baz', 'fields' => []],
-    ], $theme->layouts(TRUE));
+    ], $child_theme->layouts(TRUE));
   }
 
 }

--- a/campaignion_layout/tests/ThemesTest.php
+++ b/campaignion_layout/tests/ThemesTest.php
@@ -11,13 +11,20 @@ class ThemesTest extends DrupalUnitTestCase {
 
   /**
    * Test getting a specific theme class.
+   *
+   * @backupGlobals enabled
    */
   public function testGetTheme() {
     $themes = new Themes([
-      'foo' => (object) [],
+      'foo' => (object) ['info' => ['name' => 'Foo']],
+      'baz' => (object) ['info' => ['name' => 'Baz']],
     ], $this->createMock(\DrupalCacheInterface::class));
     $this->assertInstanceOf(Theme::class, $themes->getTheme('foo'));
     $this->assertEmpty($themes->getTheme('bar'));
+    // Set 'foo' as the currently active theme.
+    $GLOBALS['theme'] = 'foo';
+    $theme = $themes->getTheme();
+    $this->assertEqual('Foo', $theme->title());
   }
 
   /**

--- a/campaignion_layout/tests/ThemesTest.php
+++ b/campaignion_layout/tests/ThemesTest.php
@@ -68,4 +68,25 @@ class ThemesTest extends DrupalUnitTestCase {
     ], $themes->declaredLayouts());
   }
 
+  /**
+   * Test getting all layouts as options.
+   */
+  public function testLayoutOptions() {
+    $mock_themes = $this->getMockBuilder(Themes::class)
+      ->setMethods(['declaredLayouts'])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $mock_themes->method('declaredLayouts')->willReturn([
+      'foo' => ['title' => 'Foo'],
+      'bar' => ['title' => 'Bar', 'fields' => []],
+      'baz' => ['title' => 'Baz'],
+    ]);
+    $mock_themes->layoutOptions();
+    $this->assertEqual([
+      'foo' => 'Foo',
+      'bar' => 'Bar',
+      'baz' => 'Baz',
+    ], $mock_themes->layoutOptions());
+  }
+
 }

--- a/campaignion_layout/tests/ThemesTest.php
+++ b/campaignion_layout/tests/ThemesTest.php
@@ -15,7 +15,7 @@ class ThemesTest extends DrupalUnitTestCase {
   public function testGetTheme() {
     $themes = new Themes([
       'foo' => (object) [],
-    ]);
+    ], $this->createMock(\DrupalCacheInterface::class));
     $this->assertInstanceOf(Theme::class, $themes->getTheme('foo'));
     $this->assertEmpty($themes->getTheme('bar'));
   }
@@ -27,8 +27,9 @@ class ThemesTest extends DrupalUnitTestCase {
     $data['foo'] = (object) ['name' => 'foo'];
     $data['bar'] = (object) ['name' => 'bar'];
     $data['baz'] = (object) ['name' => 'baz'];
+    $cache = $this->createMock(\DrupalCacheInterface::class);
     $themes = $this->getMockBuilder(Themes::class)
-      ->setConstructorArgs([$data])
+      ->setConstructorArgs([$data, $cache])
       ->setMethods(['getTheme'])
       ->getMock();
 
@@ -55,8 +56,9 @@ class ThemesTest extends DrupalUnitTestCase {
     $bar->method('invokeLayoutHook')->willReturn([
       'bar' => ['title' => 'Bar'],
     ]);
+    $cache = $this->createMock(\DrupalCacheInterface::class);
     $themes = $this->getMockBuilder(Themes::class)
-      ->setConstructorArgs([[]])
+      ->setConstructorArgs([[], $cache])
       ->setMethods(['enabledThemes'])
       ->getMock();
     $themes->method('enabledThemes')->willReturn([$foo, $bar]);

--- a/campaignion_layout/tests/ThemesTest.php
+++ b/campaignion_layout/tests/ThemesTest.php
@@ -43,4 +43,27 @@ class ThemesTest extends DrupalUnitTestCase {
     $this->assertEqual(['foo', 'baz'], array_keys($enabled_themes));
   }
 
+  /**
+   * Test getting the declared layouts.
+   */
+  public function testDeclaredLayouts() {
+    $foo = $this->createMock(Theme::class);
+    $foo->method('invokeLayoutHook')->willReturn([
+      'foo' => ['title' => 'Foo'],
+    ]);
+    $bar = $this->createMock(Theme::class);
+    $bar->method('invokeLayoutHook')->willReturn([
+      'bar' => ['title' => 'Bar'],
+    ]);
+    $themes = $this->getMockBuilder(Themes::class)
+      ->setConstructorArgs([[]])
+      ->setMethods(['enabledThemes'])
+      ->getMock();
+    $themes->method('enabledThemes')->willReturn([$foo, $bar]);
+    $this->assertEqual([
+      'foo' => ['name' => 'foo', 'title' => 'Foo', 'fields' => []],
+      'bar' => ['name' => 'bar', 'title' => 'Bar', 'fields' => []],
+    ], $themes->declaredLayouts());
+  }
+
 }

--- a/campaignion_newsletters/tests/FormSubmissionTest.php
+++ b/campaignion_newsletters/tests/FormSubmissionTest.php
@@ -31,7 +31,7 @@ class FormSubmissionTest extends \DrupalUnitTestCase {
     $s['remote_addr'] = '127.0.0.1';
     $s['submitted'] = 4711;
     $m = new Submission($mock_node, (object) $s);
-    $fs = FormSubmission::fromWebformSubmission($m);
+    $fs = FormSubmission::fromWebformSubmission($m, 'Test user agent');
     $this->assertEquals('127.0.0.1', $fs->ip);
     $this->assertEquals(4711, $fs->date);
     $this->assertEquals(['submitted[one][two]' => 'test'], $fs->data);


### PR DESCRIPTION
- Themes share a list of layouts.
- Themes can “implement” a layout by adding it to `layout[]` of their `.info` file.
- Implemented layouts are inherited from the base theme.
- ~~Layouts can be chosen independently from the theme.~~
- ~~A chosen layout is set active when the active theme supports it (implemented & enabled) regardless of which theme override was chosen.~~
- Use one shared set of radios on the node form.
- Provide `Themes::layoutOptions()`.