### PR TITLE
[import] Fix too specific message for EntityMetadataWrapperException.

### DIFF
--- a/src/CRM/Import/Field/Address.php
+++ b/src/CRM/Import/Field/Address.php
@@ -48,21 +48,6 @@ class Address extends Field {
     return TRUE;
   }
 
-  public function import(SourceInterface $source, \EntityMetadataWrapper $entity) {
-    try {
-      if (($value = $this->getValue($source)) && ($value = $this->preprocessField($value))) {
-        if ($this->storeValue($entity, $value)) {
-          return $this->setValue($entity, $value);
-        }
-        return FALSE;
-      }
-    }
-    catch (\EntityMetadataWrapperException $e) {
-      watchdog('campaignion', 'Tried to import into a non-existing field "!field".', array('!field' => $this->field), WATCHDOG_WARNING);
-    }
-    return FALSE;
-  }
-
   public function setValue(\EntityMetadataWrapper $entity, $new_address) {
     $field = $entity->{$this->field};
     if ($field instanceof \EntityListWrapper) {

--- a/src/CRM/Import/Field/BooleanOptIn.php
+++ b/src/CRM/Import/Field/BooleanOptIn.php
@@ -46,8 +46,9 @@ class BooleanOptIn extends Field {
       } else {
         return FALSE;
       }
-    } catch (\EntityMetadataWrapperException $e) {
-      watchdog('campaignion', 'Tried to import into a non-existing field "!field".', array('!field' => $this->field), WATCHDOG_WARNING);
+    }
+    catch (\EntityMetadataWrapperException $e) {
+      watchdog_exception('campaignion', $e, 'Error when importing into !field', ['!field' => $this->field], WATCHDOG_WARNING);
     }
     return FALSE;
   }

--- a/src/CRM/Import/Field/Field.php
+++ b/src/CRM/Import/Field/Field.php
@@ -45,12 +45,12 @@ class Field {
       if (($value = $this->getValue($source)) && ($value = $this->preprocessField($value))) {
         if ($this->storeValue($entity, $value)) {
           return $this->setValue($entity, $value);
-        } else {
-          return FALSE;
         }
+        return FALSE;
       }
-    } catch (\EntityMetadataWrapperException $e) {
-      watchdog('campaignion', 'Tried to import into a non-existing field "!field".', array('!field' => $this->field), WATCHDOG_WARNING);
+    }
+    catch (\EntityMetadataWrapperException $e) {
+      watchdog_exception('campaignion', $e, 'Error when importing into !field', ['!field' => $this->field], WATCHDOG_WARNING);
     }
     return FALSE;
   }


### PR DESCRIPTION
The exception can mean several different things. By using `watchdog_exception()` sentry should give us better indication of what errors happen.

This also removes a copy of the same method in the Address sub-class.