### PR TITLE
[layout] The default layout is always enabled.

### DIFF
--- a/campaignion_layout/src/Theme.php
+++ b/campaignion_layout/src/Theme.php
@@ -120,6 +120,8 @@ class Theme {
     $variations = array_intersect_key($variations, $this->implementedLayouts());
     if (!$disabled) {
       $enabled = $this->setting('layout_variations') ?? [];
+      $default = $this->defaultLayout();
+      $enabled[$default] = $default;
       $variations = array_intersect_key($variations, array_filter($enabled));
     }
     return $variations;

--- a/campaignion_layout/tests/ThemeTest.php
+++ b/campaignion_layout/tests/ThemeTest.php
@@ -106,6 +106,7 @@ class ThemeTest extends DrupalUnitTestCase {
       'foo' => ['name' => 'foo', 'title' => 'Foo', 'fields' => []],
       'bar' => ['name' => 'bar', 'title' => 'Bar', 'fields' => []],
       'baz' => ['name' => 'baz', 'title' => 'Baz', 'fields' => []],
+      'def' => ['name' => 'def', 'title' => 'Default', 'fields' => []],
     ]);
 
     $theme = $mock_builder->setConstructorArgs([
@@ -113,13 +114,16 @@ class ThemeTest extends DrupalUnitTestCase {
         'status' => 1,
         'name' => 'foo',
         'info' => [
-          'layout' => ['foo', 'baz'],
+          'layout' => ['foo', 'baz', 'def'],
+          'layout_default' => 'def',
         ],
       ],
       $mock_themes,
     ])->getMock();
-    // No setting yet → No layouts activated.
-    $this->assertEqual([], $theme->layoutOptions());
+    // No setting yet → Only the default layout is activated.
+    $this->assertEqual([
+      'def' => 'Default',
+    ], $theme->layoutOptions());
 
     // Activate the bar-layout and baz-layout although bar is not implemented.
     $theme->method('setting')->willReturn([
@@ -129,12 +133,14 @@ class ThemeTest extends DrupalUnitTestCase {
     ]);
     $this->assertEqual([
       'baz' => 'Baz',
+      'def' => 'Default',
     ], $theme->layoutOptions());
 
     // List all implemented layouts.
     $this->assertEqual([
       'foo' => ['name' => 'foo', 'title' => 'Foo', 'fields' => []],
       'baz' => ['name' => 'baz', 'title' => 'Baz', 'fields' => []],
+      'def' => ['name' => 'def', 'title' => 'Default', 'fields' => []],
     ], $theme->layouts(TRUE));
 
     // Test child theme inheritance.
@@ -154,6 +160,7 @@ class ThemeTest extends DrupalUnitTestCase {
       'foo' => ['name' => 'foo', 'title' => 'Foo', 'fields' => []],
       'bar' => ['name' => 'bar', 'title' => 'Bar', 'fields' => []],
       'baz' => ['name' => 'baz', 'title' => 'Baz', 'fields' => []],
+      'def' => ['name' => 'def', 'title' => 'Default', 'fields' => []],
     ], $child_theme->layouts(TRUE));
   }
 


### PR DESCRIPTION
The default layout should be always enabled even if there are no settings yet, or the settings don’t enable it explicitly.

This avoids the default layout being disabled for themes that had none previously, or if the default is changed.