### PR TITLE
[campaignion_action] add action_closed_text

### DIFF
--- a/campaignion_action/campaignion_action.features.field_base.inc
+++ b/campaignion_action/campaignion_action.features.field_base.inc
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * campaignion_action.features.field_base.inc
+ */
+
+/**
+ * Implements hook_field_default_field_bases().
+ */
+function campaignion_action_field_default_field_bases() {
+  $field_bases = array();
+
+  // Exported field_base: 'action_closed_text'.
+  $field_bases['action_closed_text'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'action_closed_text',
+    'global_block_settings' => 1,
+    'indexes' => array(
+      'format' => array(
+        0 => 'format',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'text',
+    'settings' => array(),
+    'translatable' => 0,
+    'type' => 'text_long',
+  );
+
+  return $field_bases;
+}

--- a/campaignion_action/campaignion_action.info
+++ b/campaignion_action/campaignion_action.info
@@ -4,6 +4,10 @@ core = 7.x
 package = Campaignion
 
 dependencies[] = campaignion
+dependencies[] = features
 dependencies[] = little_helpers (>=2.0-alpha10)
 dependencies[] = psr0
+dependencies[] = text
 dependencies[] = webform_template
+features[features_api][] = api:2
+features[field_base][] = action_closed_text

--- a/campaignion_action/campaignion_action.module
+++ b/campaignion_action/campaignion_action.module
@@ -90,6 +90,40 @@ function campaignion_action_module_implements_alter(&$impl, $hook) {
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter() for node_form().
+ */
+function campaignion_action_form_node_form_alter(&$form, &$form_state) {
+  // Add a toggle to the `action_closed_text` to disable the action and show the text field.
+  $node = $form['#node'];
+  if (!empty($form['action_closed_text']) && isset($node->webform)) {
+    $wrapper = &$form['action_closed_text'];
+    $toggle_id = drupal_html_id('action_closed_toggle');
+    $wrapper['toggle'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Deactivate this action'),
+      '#description' => t('Removes the webform and shows a replacement content instead.'),
+      '#default_value' => $node->webform['status'] ? 0 : 1,
+      '#parents' => ['action_closed_toggle'],
+      '#id' => $toggle_id,
+      '#weight' => -1,
+    ];
+    $wrapper[$wrapper['#language']]['#type'] = 'container';
+    $wrapper[$wrapper['#language']]['#states']['visible']["#$toggle_id"]['checked'] = TRUE;
+  }
+}
+
+/**
+ * Implements hook_node_submit().
+ */
+function campaignion_action_node_submit($node, $form, &$form_state) {
+  // Set webform status.
+  $action_closed = &$form_state['values']['action_closed_toggle'] ?? NULL;
+  if ($action_closed !== NULL) {
+    $node->webform['status'] = $action_closed ? 0 : 1;
+  }
+}
+
+/**
  * Implements hook_permission().
  */
 function campaignion_action_permission() {
@@ -120,6 +154,11 @@ function campaignion_action_node_view($node) {
         drupal_set_message($link_text, 'status', FALSE);
       }
     }
+  }
+  // Remove `action_closed_text` when there is a webform.
+  if (!empty($node->webform['status'])) {
+    unset($node->action_closed_text);
+    unset($node->content['action_closed_text']);
   }
 }
 

--- a/campaignion_action/campaignion_action.module
+++ b/campaignion_action/campaignion_action.module
@@ -93,7 +93,8 @@ function campaignion_action_module_implements_alter(&$impl, $hook) {
  * Implements hook_form_FORM_ID_alter() for node_form().
  */
 function campaignion_action_form_node_form_alter(&$form, &$form_state) {
-  // Add a toggle to the `action_closed_text` to disable the action and show the text field.
+  // Add a toggle to the `action_closed_text` to disable the action and show
+  // the text field.
   $node = $form['#node'];
   if (!empty($form['action_closed_text']) && isset($node->webform)) {
     $wrapper = &$form['action_closed_text'];
@@ -394,4 +395,26 @@ function campaignion_action_campaignion_action_taken($node, Submission $submissi
     $contact->save();
   }
   return $contact;
+}
+
+/**
+ * Implements hook_theme_registry_alter().
+ */
+function campaignion_action_theme_registry_alter(&$theme_registry) {
+  // Use this module’s theme_webform_view_messages().
+  $webform_messages = &$theme_registry['webform_view_messages'];
+  $webform_messages['theme_path'] = drupal_get_path('module', 'campaignion_action');
+  $webform_messages['function'] = 'campaignion_action_webform_view_messages';
+}
+
+/**
+ * Implements theme_webform_view_messages().
+ *
+ * Don’t display any Drupal messages on closed forms when the node has a
+ * `action_closed_text` field.
+ */
+function campaignion_action_webform_view_messages($variables) {
+  if (empty($variables['closed']) || empty($variables['node']->action_closed_text)) {
+    return theme_webform_view_messages($variables);
+  }
 }

--- a/campaignion_action/tests/NodeFormTest.php
+++ b/campaignion_action/tests/NodeFormTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\campaignion_action;
+
+use Upal\DrupalUnitTestCase;
+
+/**
+ * Test for the node hook implementations.
+ */
+class NodeFormTest extends DrupalUnitTestCase {
+
+  /**
+   * Test form alter with an empty form and node.
+   */
+  public function testFormAlterEmptyForm() {
+    $form['#node'] = (object) [];
+    $form_state = [];
+    $original_form = $form;
+    campaignion_action_form_node_form_alter($form, $form_state);
+    $this->assertEquals($original_form, $form);
+  }
+
+  /**
+   * Test form alter on non-webform node.
+   */
+  public function testFormAlterNoWebform() {
+    $form['#node'] = (object) [];
+    $form['action_closed_text'] = [];
+    $form_state = [];
+    $original_form = $form;
+    campaignion_action_form_node_form_alter($form, $form_state);
+    $this->assertEquals($original_form, $form);
+  }
+
+  /**
+   * Test form alter with field and webform.
+   */
+  public function testFormAlter() {
+    $form['#node'] = (object) ['webform' => ['status' => 1]];
+    $form['action_closed_text']['#language'] = LANGUAGE_NONE;
+    $form['action_closed_text'][LANGUAGE_NONE][] = [];
+    $form_state = [];
+    $expected_wrapper = $form['action_closed_text'];
+    campaignion_action_form_node_form_alter($form, $form_state);
+    $this->assertArrayHasKey('toggle', $form['action_closed_text']);
+    $this->assertEquals('checkbox', $form['action_closed_text']['toggle']['#type']);
+
+    $this->assertEquals('container', $form['action_closed_text'][LANGUAGE_NONE]['#type']);
+    $states['visible']["#{$form['action_closed_text']['toggle']['#id']}"]['checked'] = TRUE;
+    $this->assertEquals($states, $form['action_closed_text'][LANGUAGE_NONE]['#states']);
+  }
+
+  /**
+   * Test the node submit handler without value.
+   */
+  public function testNodeSubmitWithoutValue() {
+    $node = (object) ['webform' => ['status' => 2]];
+    $form_state = [];
+    campaignion_action_node_submit($node, [], $form_state);
+    $this->assertEquals(2, $node->webform['status']);
+  }
+
+  /**
+   * Test the node submit handler with a value.
+   */
+  public function testNodeSubmitWithValue() {
+    $node = (object) ['webform' => ['status' => 2]];
+    $form_state['values']['action_closed_toggle'] = 'trueish';
+    campaignion_action_node_submit($node, [], $form_state);
+    $this->assertEquals(0, $node->webform['status']);
+  }
+
+  /**
+   * Test hook_node_view() on open form.
+   */
+  public function testNodeView() {
+    $node = (object) [
+      'status' => NODE_PUBLISHED,
+      'webform' => ['status' => 1],
+      'content' => ['action_closed_text' => ['#markup' => 'content']],
+    ];
+    campaignion_action_node_view($node);
+    $this->assertArrayNotHasKey('action_closed_text', $node->content);
+  }
+
+}


### PR DESCRIPTION
Adds a field to disable the webform from the node edit form and replace
it with some other content. The field can be added to any node type with
a webform.