### PR TITLE
Missing class Drupal\campaignion_auth\ConfigError

### DIFF
--- a/campaignion_auth/src/ConfigError.php
+++ b/campaignion_auth/src/ConfigError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Drupal\campaignion_auth;
+
+/**
+ * Class signifying an error in the configuration.
+ */
+class ConfigError extends \RuntimeException {}

--- a/campaignion_auth/tests/AuthAppClientTest.php
+++ b/campaignion_auth/tests/AuthAppClientTest.php
@@ -55,4 +55,12 @@ class AuthAppClientTest extends \DrupalUnitTestCase {
     $this->assertEqual($token, $token2);
   }
 
+  /**
+   * Test config validation for an empty API-key.
+   */
+  public function testValidateConfigEmptyKey() {
+    $this->expectException(ConfigError::class);
+    $api = new AuthAppClient('http://url', [], 'org');
+  }
+
 }

--- a/campaignion_email_to_target/campaignion_email_to_target.install
+++ b/campaignion_email_to_target/campaignion_email_to_target.install
@@ -5,7 +5,7 @@
  * campaignion_email_to_target.install
  */
 
-use Drupal\campaignion_email_to_target\Api\ConfigError;
+use Drupal\campaignion_auth\ConfigError;
 use Drupal\campaignion_email_to_target\NullCacheBin;
 use Drupal\little_helpers\Services\Container;
 

--- a/campaignion_email_to_target/src/Api/ConfigError.php
+++ b/campaignion_email_to_target/src/Api/ConfigError.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Drupal\campaignion_email_to_target\Api;
-
-/**
- * Class signifying an error in the configuration of the e2t-api connection.
- */
-class ConfigError extends \RuntimeException {}


### PR DESCRIPTION
Referenced in Drupal\campaignion_auth\AuthAppClient but not defined.