### PR TITLE
[form_builder] Remove obsolete JS loading workaround.

### DIFF
--- a/campaignion_form_builder/campaignion_form_builder.module
+++ b/campaignion_form_builder/campaignion_form_builder.module
@@ -213,15 +213,3 @@ function campaignion_form_builder_admin_paths() {
     );
   }
 }
-
-/**
- * Implements hook_form_FORM_ID_alter().
- * Implements hook_form_form_builder_webform_save_form_alter().
- *
- * Work around for form_builder.js not loading additional Javascripts. Make
- * states.js work.
- */
-function campaignion_form_builder_form_form_builder_webform_save_form_alter(&$form, &$form_state) {
-  $form['#attached']['js'][] = 'misc/ajax.js';
-  $form['#attached']['js'][] = 'misc/states.js';
-}


### PR DESCRIPTION
I came across this because I found that loading these scripts with `drupal_add_js()` (via `#attached`) breaks the loading order. Core JS should only be loaded as library (if it’s exposed as such).

Also this seems to be a workaround for a fixed issue in form_builder in the first place. Since form_builder switched to using more of the core Ajax handling loading JS dynamically just works. So no need for the workaround.