### PR TITLE
[facebook_pixel] fix fbq dummy

### DIFF
--- a/campaignion_facebook_pixel/campaignion_facebook_pixel.module
+++ b/campaignion_facebook_pixel/campaignion_facebook_pixel.module
@@ -39,11 +39,7 @@ function campaignion_facebook_pixel_little_helpers_services() {
 function campaignion_facebook_pixel_campaignion_tracking_snippets() {
   $snippets['facebook_pixel'] = <<<SNIPPET
 !function(f,b,e,v,n,t,s){if(f.fbq&&!f.fbq.dummy)return;
-if(!f.fbq){
-n=f.fbq=function(){n.callMethod?
-n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];}
-else{f.fbq.dummy=0}
+f.fbq.dummy=0;
 t=b.createElement(e);t.async=!0;
 t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
 document,'script','https://connect.facebook.net/en_US/fbevents.js');

--- a/campaignion_facebook_pixel/campaignion_facebook_pixel.module
+++ b/campaignion_facebook_pixel/campaignion_facebook_pixel.module
@@ -38,9 +38,13 @@ function campaignion_facebook_pixel_little_helpers_services() {
  */
 function campaignion_facebook_pixel_campaignion_tracking_snippets() {
   $snippets['facebook_pixel'] = <<<SNIPPET
-!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+!function(f,b,e,v,n,t,s){if(f.fbq&&!f.fbq.dummy)return;
+if(!f.fbq){
+n=f.fbq=function(){n.callMethod?
 n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];}
+else{f.fbq.dummy=0}
+t=b.createElement(e);t.async=!0;
 t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
 document,'script','https://connect.facebook.net/en_US/fbevents.js');
 SNIPPET;

--- a/campaignion_facebook_pixel/fb-pixel.js
+++ b/campaignion_facebook_pixel/fb-pixel.js
@@ -1,7 +1,7 @@
 // Define the loading-dummy for fbq if needed. Don’t load the actual script.
 !function(f,n){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
 n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-n.push=n;n.loaded=!0;n.version='2.0';n.queue=[]}(window);
+n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];n.dummy=!0}(window);
 
 // Read the URL fragment and send all events.
 (function () {


### PR DESCRIPTION
Modify snippet so it still loads fbevents.js when a dummy exists.