### PR TITLE
Switched from load to DomContentLoaded event

### DIFF
--- a/campaignion_webform_widget/js/widget.js
+++ b/campaignion_webform_widget/js/widget.js
@@ -49,18 +49,14 @@ function gaLinkerHandler() {
   }
 }
 
-if (window.addEventListener) {
-  window.addEventListener("DOMContentLoaded", function() {
-    gaLinkerHandler();
-    messageParent();
-    window.addEventListener("DOMSubtreeModified", messageParent, true);
-  });
-}
-else {
-  window.onload = function() {
-    messageParent();
-    window.attachEvent("onDOMSubtreeModified", messageParent);
-  }
+window.addEventListener("DOMContentLoaded", function() {
+  gaLinkerHandler();
+  messageParent();
+});
+
+window.onload = function() {
+  messageParent();
+  window.addEventListener("DOMSubtreeModified", messageParent, true);
 }
 
 window.onresize = function() {

--- a/campaignion_webform_widget/js/widget.js
+++ b/campaignion_webform_widget/js/widget.js
@@ -49,18 +49,20 @@ function gaLinkerHandler() {
   }
 }
 
-function registerListeners() {
-  if (window.addEventListener) {
-    window.addEventListener("DOMSubtreeModified", function(){messageParent();}, true);
-    document.addEventListener("DOMContentLoaded", gaLinkerHandler);
-  } else if (window.attachEvent) {
-    window.attachEvent("onDOMSubtreeModified", function(){messageParent();});
+if (window.addEventListener) {
+  window.addEventListener("DOMContentLoaded", function() {
+    gaLinkerHandler();
+    messageParent();
+    window.addEventListener("DOMSubtreeModified", messageParent, true);
+  });
+}
+else {
+  window.onload = function() {
+    messageParent();
+    window.attachEvent("onDOMSubtreeModified", messageParent);
   }
 }
-window.onload = function() {
-  messageParent();
-  registerListeners();
-}
+
 window.onresize = function() {
   messageParent();
 }


### PR DESCRIPTION
I've updated this widget as part of a solution to the MO website's 'Contact Us' form loading very slowly... it turns out that the time difference between the `DOMContentLoaded` event and the `load` event is in the order of 600-1000ms, which is almost certainly due to the recaptcha script. I see that Alex was the original developer for this, but as he's not here, could I ask for a little verification that this is not going to break anything I don't know about? :)