### PR TITLE
[newsletter] Add index for queue item select query

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters.install
+++ b/campaignion_newsletters/campaignion_newsletters.install
@@ -164,6 +164,8 @@ function campaignion_newsletters_schema() {
       'primary key' => ['id'],
       'indexes' => [
         'list_email' => ['list_id', 'email'],
+        'created' => ['created'],
+        'locked' => ['locked'],
       ],
     ],
   ];
@@ -193,6 +195,14 @@ function campaignion_newsletters_uninstall() {
   variable_del('campaignion_newsletters_batch_size');
   variable_del('campaignion_newsletters_last_list_poll');
   variable_del('campaignion_newsletters_poll_time');
+}
+
+/**
+ * Add indexes for campaignion_newsletters_queue.locked and .created.
+ */
+function campaignion_newsletters_update_22() {
+  db_add_index('campaignion_newsletters_queue', 'locked', ['locked']);
+  db_add_index('campaignion_newsletters_queue', 'created', ['created']);
 }
 
 /**


### PR DESCRIPTION
The queue might have many (~100k) entries so filtering on an unindexed locked column can cause performance issues (as observed). This adds indexes on locked and created.

https://github.com/moreonion/campaignion/blob/17eafbd1002fb80ee4e641e59f3a823516b417dd/campaignion_newsletters/src/QueueItem.php#L146-L154