### PR TITLE
[fix] Newsletters: QueueItem keep subscribe op when updating data

### DIFF
--- a/campaignion_newsletters/tests/SubscriptionTest.php
+++ b/campaignion_newsletters/tests/SubscriptionTest.php
@@ -71,6 +71,43 @@ class SubscriptionTest extends \DrupalWebTestCase {
   }
 
   /**
+   * Test opt-in then update: QueueItem keeps subscribe status.
+   */
+  public function testOptInThenUpdate() {
+    $email = 'subscriber@example.com';
+    $list_id = 4711;
+    $provider = $this->createMock(ProviderInterface::class);
+    $provider->method('data')->will($this->onConsecutiveCalls(
+      [['data'], 'fingerprint'],
+      [['new-data'], 'new-fingerprint']
+    ));
+    $s = $this->getMockBuilder(Subscription::class)
+      ->setMethods(['provider'])
+      ->setConstructorArgs([[
+        'list_id' => $list_id,
+        'email' => $email,
+      ], TRUE])
+      ->getMock();
+    $s->method('provider')->willReturn($provider);
+
+    // Initial opt-in.
+    $s->save();
+
+    // Subcribe QueueItem
+    $item = QueueItem::load($list_id, $email);
+    $this->assertEqual(QueueItem::SUBSCRIBE, $item->action);
+    $this->assertEqual(['data'], $item->data);
+
+    // Update subscription data.
+    $s->save();
+
+    // QueueItem is still for subscribing although the data was updated.
+    $item = QueueItem::load($list_id, $email);
+    $this->assertEqual(QueueItem::SUBSCRIBE, $item->action);
+    $this->assertEqual(['new-data'], $item->data);
+  }
+
+  /**
    * Test merging subscriptions.
    */
   public function testMerge() {


### PR DESCRIPTION
Most of the newsletter providers treat subscribes and updates the same, but some (DaDi) don’t. When new subscriptions are updated while being queued the `$item->action` should not be changed, otherwise data might be lost.