### PR TITLE
e2t: Make channels responsible for filtering targets

### DIFF
--- a/campaignion_email_to_target/src/Action.php
+++ b/campaignion_email_to_target/src/Action.php
@@ -43,10 +43,9 @@ class Action extends ActionBase {
    * Choose an appropriate message for a given target.
    */
   public function getMessage($target) {
-    $is_stub = empty($target['email']);
     $templates = MessageTemplate::byNid($this->node->nid);
     foreach ($templates as $t) {
-      if ((!$is_stub || $t->type == 'exclusion') && $t->checkFilters($target)) {
+      if ($t->checkFilters($target)) {
         return $t->createInstance();
       }
     }

--- a/campaignion_email_to_target/src/Action.php
+++ b/campaignion_email_to_target/src/Action.php
@@ -7,6 +7,7 @@ use Drupal\campaignion_action\ActionType;
 use Drupal\campaignion_email_to_target\Api\Client;
 use Drupal\campaignion_email_to_target\Channel\Email;
 use Drupal\little_helpers\Services\Container;
+use Drupal\little_helpers\Services\Spec;
 use Drupal\little_helpers\Webform\Submission;
 
 /**
@@ -176,27 +177,12 @@ class Action extends ActionBase {
 
   /**
    * Get the configured channel.
-   */
-  public function channel() {
-    return $this->pluginInstance($this->parameters['channel']);
-  }
-
-  /**
-   * Create a new plugin instance based on a specification.
-   *
-   * @param mixed $spec
-   *   A spec can either be a fully qualified class name or an array with at
-   *   least one member 'class' which must be a fully qualified class name.
    *
    * @return mixed
-   *   A new plugin instance.
+   *   A new channel instance based on the action type’s configuration.
    */
-  protected function pluginInstance($spec) {
-    if (!is_array($spec)) {
-      $spec = ['class' => $spec];
-    }
-    $class = $spec['class'];
-    return $class::fromConfig($spec);
+  public function channel() {
+    return Spec::fromInfo($this->parameters['channel'])->instantiate();
   }
 
 }

--- a/campaignion_email_to_target/src/Channel/Email.php
+++ b/campaignion_email_to_target/src/Channel/Email.php
@@ -12,13 +12,6 @@ use Drupal\campaignion_email_to_target\Message;
 class Email {
 
   /**
-   * Create a new instance based on some config.
-   */
-  public static function fromConfig(array $config) {
-    return new static();
-  }
-
-  /**
    * Send email to one target.
    *
    * @param \Drupal\campaignion_email_to_target\Message $message

--- a/campaignion_email_to_target/src/Channel/Email.php
+++ b/campaignion_email_to_target/src/Channel/Email.php
@@ -112,4 +112,23 @@ class Email {
     ];
   }
 
+  /**
+   * Remove or modify targets and messages for this channel.
+   */
+  public function filterPairs(array $pairs, Submission $submission, bool $test_mode) {
+    $submission_email = $submission->valueByKey('email');
+    $new_pairs = [];
+    foreach ($pairs as $pair) {
+      list($target, $message) = $pair;
+      if (empty($target['email'])) {
+        continue;
+      }
+      if ($test_mode) {
+        $target['email'] = $submission_email;
+      }
+      $new_pairs[] = [$target, $message];
+    }
+    return $new_pairs;
+  }
+
 }

--- a/campaignion_email_to_target/src/Channel/NoOp.php
+++ b/campaignion_email_to_target/src/Channel/NoOp.php
@@ -12,13 +12,6 @@ use Drupal\campaignion_email_to_target\Message;
 class NoOp {
 
   /**
-   * Create a new instance based on some config.
-   */
-  public static function fromConfig(array $config) {
-    return new static();
-  }
-
-  /**
    * Send email to one target.
    *
    * @param \Drupal\campaignion_email_to_target\Message $message

--- a/campaignion_email_to_target/src/Channel/NoOp.php
+++ b/campaignion_email_to_target/src/Channel/NoOp.php
@@ -46,4 +46,11 @@ class NoOp {
     ];
   }
 
+  /**
+   * Remove or modify targets and messages for this channel.
+   */
+  public function filterPairs(array $pairs) {
+    return $pairs;
+  }
+
 }

--- a/campaignion_email_to_target/src/Component.php
+++ b/campaignion_email_to_target/src/Component.php
@@ -130,7 +130,7 @@ class Component {
     $element['#attributes']['class'][] = 'webform-prefill-exclude';
 
     try {
-      $pairs_or_exclusion = $this->action->targetMessagePairs($submission_o, $test_mode);
+      $pairs_or_exclusion = $this->action->targetMessagePairs($submission_o, $channel, $test_mode);
     }
     catch (\Exception $e) {
       watchdog_exception('campaignion_email_to_target', $e);

--- a/campaignion_email_to_target/tests/ActionTest.php
+++ b/campaignion_email_to_target/tests/ActionTest.php
@@ -2,9 +2,10 @@
 
 namespace Drupal\campaignion_email_to_target;
 
-use \Drupal\campaignion_action\Loader;
-use \Drupal\campaignion_email_to_target\Api\Client;
-use \Drupal\little_helpers\Webform\Submission;
+use Drupal\campaignion_action\Loader;
+use Drupal\campaignion_email_to_target\Api\Client;
+use Drupal\campaignion_email_to_target\Channel\NoOp;
+use Drupal\little_helpers\Webform\Submission;
 
 class ActionTest extends \DrupalUnitTestCase {
 
@@ -90,7 +91,7 @@ class ActionTest extends \DrupalUnitTestCase {
       }
       return $m;
     }));
-    $pairs = $action->targetMessagePairs($submission_o);
+    $pairs = $action->targetMessagePairs($submission_o, new NoOp(), FALSE);
     $this->assertEqual([[$contacts[0], $m], [$contacts[2], $m]], $pairs);
   }
 
@@ -116,7 +117,7 @@ class ActionTest extends \DrupalUnitTestCase {
         'message' => 'excluded!',
       ]);
     }));
-    $exclusion = $action->targetMessagePairs($submission_o);
+    $exclusion = $action->targetMessagePairs($submission_o, new NoOp(), FALSE);
     $this->assertEqual(['#markup' => "<p>excluded first!</p>\n"], $exclusion->renderable());
   }
 
@@ -125,9 +126,8 @@ class ActionTest extends \DrupalUnitTestCase {
    */
   public function testTargetMessagePairsDefaultExclusion() {
     list($action, $api, $submission_o) = $this->mockAction([]);
-    $exclusion = $action->targetMessagePairs($submission_o);
+    $exclusion = $action->targetMessagePairs($submission_o, new NoOp(), FALSE);
     $this->assertEqual(['#markup' => '<p>Default exclusion</p>'], $exclusion->renderable()[0]);
   }
 
 }
-

--- a/campaignion_email_to_target/tests/Channel/EmailTest.php
+++ b/campaignion_email_to_target/tests/Channel/EmailTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\campaignion_email_to_target\Channel;
 
 use Drupal\campaignion_email_to_target\Message;
+use Drupal\little_helpers\Webform\Submission;
 
 /**
  * Test the “Email” channel.
@@ -59,6 +60,43 @@ class EmailTest extends \DrupalUnitTestcase {
     drupal_process_form('e2t_component_element', $element, $form_state);
     $rendered = drupal_render($element);
     $this->assertStringContainsString('<p class="email-to-target-subject"><strong>Subject&#039;s string</strong></p>', $rendered);
+  }
+
+  /**
+   * Test filterPairs() removes targets without email address.
+   */
+  public function testFilterPairsWithoutEmail() {
+    $pairs = [
+      [['email' => 'test1@example.com', 'name' => 'One'], []],
+      [['Name' => 'No email'], []],
+      [['email' => 'test2@example.com', 'name' => 'Two'], []],
+    ];
+    $channel = new Email();
+    $submission = $this->createMock(Submission::class);
+    $submission->method('valueByKey')->willReturn('test-mode@example.com');
+    $new_pairs = $channel->filterPairs($pairs, $submission, FALSE);
+    $this->assertEqual([$pairs[0], $pairs[2]], $new_pairs);
+  }
+
+  /**
+   * Test filterPairs() replaces email addresses of targets in test-mode.
+   *
+   * Targets without email are still excluded.
+   */
+  public function testFilterPairsTestMode() {
+    $pairs = [
+      [['email' => 'test1@example.com', 'name' => 'One'], []],
+      [['Name' => 'No email'], []],
+      [['email' => 'test2@example.com', 'name' => 'Two'], []],
+    ];
+    $channel = new Email();
+    $submission = $this->createMock(Submission::class);
+    $submission->method('valueByKey')->willReturn('test-mode@example.com');
+    $new_pairs = $channel->filterPairs($pairs, $submission, TRUE);
+    $this->assertEqual([
+      [['email' => 'test-mode@example.com', 'name' => 'One'], []],
+      [['email' => 'test-mode@example.com', 'name' => 'Two'], []],
+    ], $new_pairs);
   }
 
 }


### PR DESCRIPTION
This makes the code that removes targets without email addresses from the Component into the Email channel and thus makes it channel specific.