### PR TITLE
[wizard] Avoid double execution of old hook_form_alter() implementations

### DIFF
--- a/campaignion_wizard/src/ContentStep.php
+++ b/campaignion_wizard/src/ContentStep.php
@@ -21,6 +21,8 @@ class ContentStep extends WizardStep {
     // load original node form
     $form_state['embedded']['#wizard_type'] = 'content';
     $this->nodeForm = new EmbeddedNodeForm($this->wizard->node, $form_state);
+    // Don’t re-execute alter-functions that listen to this property.
+    $form['#node_edit_form'] = FALSE;
     $form += $this->nodeForm->formArray($form);
 
     // we don't want the webform_template selector to show up here.


### PR DESCRIPTION
Very old code used `hook_form_alter()` and a check for `$form['#node_edit_form']` when altering node edit forms. `EmbeddedNodeForm::alterForm()` already takes care of executing all relevent alter functions, so we have to avoid to re-execute them when `hook_form_alter()` is invoked for the wizard form `form_id = 'oowizard_form'`.

Most hook implementations now (D7+) use `hook_form_FORM_ID_alter()` or a check for the `$form_id` value in `hook_form_alter()` to achieve the same.

Example of an old implementation where this is relevant: `domain_form_alter()`.