### PR TITLE
Restructure expiry functions

### DIFF
--- a/campaignion_expiry/campaignion_expiry.module
+++ b/campaignion_expiry/campaignion_expiry.module
@@ -7,6 +7,7 @@
 
 use Drupal\campaignion_expiry\ContactCron;
 use Drupal\campaignion_expiry\SubmissionCron;
+use Drupal\campaignion_expiry\Anonymizer;
 use Drupal\little_helpers\Services\Container;
 
 /**
@@ -30,8 +31,14 @@ function campaignion_expiry_little_helpers_services() {
   $info['campaignion_expiry.ContactCron'] = [
     'class' => ContactCron::class,
     'arguments' => [
+      '@campaignion_expiry.Anonymizer',
       '!campaignion_expiry_cron_time_limit',
       '!campaignion_expiry_contact_time_frame',
+    ],
+  ];
+  $info['campaignion_expiry.Anonymizer'] = [
+    'class' => Anonymizer::class,
+    'arguments' => [
       '!campaignion_expiry_contact_keep_mp_data',
     ],
   ];

--- a/campaignion_expiry/src/Anonymizer.php
+++ b/campaignion_expiry/src/Anonymizer.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\campaignion_expiry;
+
+use Drupal\campaignion\Contact;
+
+/**
+ * Anonymization service for redhen contacts.
+ */
+class Anonymizer {
+
+  /**
+   * Anonymize a single contact.
+   *
+   * @param bool $keep_mp_fields
+   *   If TRUE the MP data is copied to the anonymized contacts, otherwise it is
+   *   deleted.
+   */
+  public function __construct($contact, bool $keep_mp_fields = FALSE) {
+    $this->contact = $contact;
+    $this->keepMpFields = $keep_mp_fields;
+    $this->entityController = entity_get_controller('redhen_contact');
+  }
+
+  /**
+   * Create a new anonymous contact and copy over some data we want to keep.
+   *
+   * @param \Drupal\campaignion\Contact $contact
+   *   Contact that is being anonymized.
+   */
+  public function anonymize(Contact $contact) {
+    $new_contact = new Contact();
+    $new_contact->contact_id = $contact->contact_id;
+    $new_contact->redhen_state = REDHEN_STATE_ARCHIVED;
+    $new_contact->setEmail("{$contact->contact_id}@deleted");
+
+    $new_contact->first_name = 'Anonymous';
+    $new_contact->last_name = $contact->contact_id;
+
+    // Copy first country of $contact to $new_contact.
+    foreach ($contact->wrap()->field_address->value() as $item) {
+      if (!empty($item['country'])) {
+        $new_contact->wrap()->field_address->set([['country' => $item['country']]]);
+        break;
+      }
+    }
+
+    // Copy tags of $contact to $new_contact.
+    $new_contact->supporter_tags = $contact->supporter_tags;
+    $new_contact->campaign_tag = $contact->campaign_tag;
+    $new_contact->source_tag = $contact->source_tag;
+
+    // Copy MP fields of $contact to $new_contact.
+    if ($this->keepMpFields) {
+      $new_contact->mp_constituency = $contact->mp_constituency;
+      $new_contact->mp_country = $contact->mp_country;
+      $new_contact->mp_party = $contact->mp_party;
+      $new_contact->mp_salutation = $contact->mp_salutation;
+    }
+
+    $new_contact->created = $contact->created;
+    $new_contact->log = "Contact “{$contact->contact_id}” and has been anonymized";
+    $new_contact->save();
+
+    $this->entityController->resetCache([$contact->contact_id]);
+  }
+
+  /**
+   * Delete all but the last revision of a contact.
+   *
+   * @param \Drupal\campaignion\Contact $contact
+   *   The contact which’s revisions should be removed.
+   */
+  public function deleteOldRevisions(Contact $contact) {
+    $sql_revisions = <<<SQL
+SELECT revision_id
+FROM redhen_contact_revision
+WHERE contact_id=:current_contact_id
+ORDER BY revision_id;
+SQL;
+
+    $current_contact_id = $contact->contact_id;
+    $revisions = db_query($sql_revisions, [':current_contact_id' => $current_contact_id])->fetchCol();
+    foreach ($revisions as $revision) {
+      entity_revision_delete('redhen_contact', $revision);
+    }
+  }
+}

--- a/campaignion_expiry/src/ContactCron.php
+++ b/campaignion_expiry/src/ContactCron.php
@@ -3,6 +3,7 @@
 namespace Drupal\campaignion_expiry;
 
 use Drupal\campaignion\Contact;
+use Drupal\campaignion_expiry\Anonymizer;
 
 /**
  * Cron-job for expiring old contact records.
@@ -18,81 +19,14 @@ class ContactCron {
    * @param string $inactive_since_str
    *   String that can be passed to strtotime(). Expire all contacts that didn’t
    *   have any activity logged in this time frame.
-   * @param bool $keep_mp_fields
-   *   If TRUE the MP data is copied to the anonymized contacts, otherwise it is
-   *   deleted.
    */
-  public function __construct(int $time_limit, string $inactive_since_str, bool $keep_mp_fields = FALSE) {
+  public function __construct(Anonymizer $anonymizer, int $time_limit, string $inactive_since_str) {
+    $this->anonymizer = $anonymizer;
     $this->timeLimit = $time_limit;
     $this->inactiveSinceStr = $inactive_since_str;
-    $this->keepMpFields = $keep_mp_fields;
     $this->entityController = entity_get_controller('redhen_contact');
   }
 
-  /**
-   * Create a new anonymous contact and copy over some data we want to keep.
-   *
-   * @param \Drupal\campaignion\Contact $contact
-   *   Contact that is being anonymized.
-   */
-  protected function anonymize(Contact $contact) {
-    $new_contact = new Contact();
-    $new_contact->contact_id = $contact->contact_id;
-    $new_contact->redhen_state = REDHEN_STATE_ARCHIVED;
-    $new_contact->setEmail("{$contact->contact_id}@deleted");
-
-    $new_contact->first_name = 'Anonymous';
-    $new_contact->last_name = $contact->contact_id;
-
-    // Copy first country of $contact to $new_contact.
-    foreach ($contact->wrap()->field_address->value() as $item) {
-      if (!empty($item['country'])) {
-        $new_contact->wrap()->field_address->set([['country' => $item['country']]]);
-        break;
-      }
-    }
-
-    // Copy tags of $contact to $new_contact.
-    $new_contact->supporter_tags = $contact->supporter_tags;
-    $new_contact->campaign_tag = $contact->campaign_tag;
-    $new_contact->source_tag = $contact->source_tag;
-
-    // Copy MP fields of $contact to $new_contact.
-    if ($this->keepMpFields) {
-      $new_contact->mp_constituency = $contact->mp_constituency;
-      $new_contact->mp_country = $contact->mp_country;
-      $new_contact->mp_party = $contact->mp_party;
-      $new_contact->mp_salutation = $contact->mp_salutation;
-    }
-
-    $new_contact->created = $contact->created;
-    $new_contact->log = "Contact not being updated since “{$this->inactiveSinceStr}” and has been anonymized";
-    $new_contact->save();
-
-    $this->entityController->resetCache([$contact->contact_id]);
-  }
-
-  /**
-   * Delete all but the last revision of a contact.
-   *
-   * @param \Drupal\campaignion\Contact $contact
-   *   The contact which’s revisions should be removed.
-   */
-  protected function deleteOldRevisions(Contact $contact) {
-    $sql_revisions = <<<SQL
-SELECT revision_id
-FROM redhen_contact_revision
-WHERE contact_id=:current_contact_id
-ORDER BY revision_id;
-SQL;
-
-    $current_contact_id = $contact->contact_id;
-    $revisions = db_query($sql_revisions, [':current_contact_id' => $current_contact_id])->fetchCol();
-    $last_revision = array_pop($revisions);
-    foreach ($revisions as $revision) {
-      entity_revision_delete('redhen_contact', $revision);
-    }
-  }
 
   /**
    * Load inactive contacts from the database.
@@ -132,8 +66,8 @@ SQL;
     watchdog('campaignion_expiry', 'Expiring contacts inactive since @time', $args, WATCHDOG_INFO);
     while (time() < $stop_after && ($contacts = $this->loadInactiveContacts($inactive_since, $last_id))) {
       foreach ($contacts as $contact) {
-        $this->anonymize($contact);
-        $this->deleteOldRevisions($contact);
+        $this->anonymizer->anonymize($contact);
+        $this->anonymizer->deleteOldRevisions($contact);
         $last_id = $contact->contact_id;
         $contact_count++;
       }

--- a/campaignion_expiry/tests/AnonymizeContactTest.php
+++ b/campaignion_expiry/tests/AnonymizeContactTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\campaignion_expiry;
+
+use Drupal\campaignion\Contact;
+use Drupal\campaignion\ContactTypeManager;
+use Drupal\campaignion\CRM\Import\Source\ArraySource;
+use Drupal\campaignion_expiry\Anonymizer;
+use Upal\DrupalUnitTestCase;
+
+/**
+ * Test anonymizing a contact.
+ */
+class AnonymizerTest extends DrupalUnitTestCase {
+
+  /**
+   * Create a test contact that can be anonymized.
+   */
+  public function setUp() : void {
+    parent::setUp();
+    $this->contact = Contact::fromBasicData('test@example.com', 'First', 'Last', 'contact');
+    $this->contact->save();
+  }
+
+  /**
+   * Delete our test contact created in set up when the tests are finished.
+   */
+  public function tearDown() : void {
+    $this->contact->delete();
+    parent::tearDown();
+  }
+
+  /**
+   * Test anonymizing our contact.
+   */
+  public function testContactAnonymization() {
+    $anonymizer = new Anonymizer(false);
+    $anonymizer->anonymize($this->contact, false);
+    $anonymizer->deleteOldRevisions($this->contact);
+
+    $contact = entity_load_single('redhen_contact', $this->contact->contact_id);
+    $old_contact = $this->contact;
+
+    // Is a contact record still there?
+    $this->assertNotEmpty($contact);
+    // Did the first name change to "Anonymous" as specified in the Anonymizer?
+    $this->assertEqual($contact->first_name, "Anonymous");
+    // Did the revision change?
+    $this->assertNotEquals($contact->revision_id, $old_contact->revision_id);
+    // Was the old revision deleted?
+    $this->assertFalse(entity_revision_load('redhen_contact', $old_contact->revision_id));
+  }
+}


### PR DESCRIPTION
Goal:
Have a function for other scripts to anonymise individual contacts.
Add a little_helpers service to anonymise a contact.
Expiry Cron jobs should call it instead of providing this functionality themselves.