### PR TITLE
Update webform_confirm_email: Simplify handling of confirmed timestamps

### DIFF
--- a/campaignion_activity/campaignion_activity.install
+++ b/campaignion_activity/campaignion_activity.install
@@ -163,6 +163,36 @@ function campaignion_activity_uninstall() {
 }
 
 /**
+ * Implements hook_update_dependencies().
+ */
+function campaignion_activity_update_dependencies() {
+  $dependencies = [];
+  // Nothing to do if the webform_confirm_email module wasn’t enabled before.
+  if (drupal_get_installed_schema_version('webform_confirm_email') != SCHEMA_UNINSTALLED) {
+    $dependencies['campaignion_activity'][10]['webform_confirm_email'] = 7211;
+  }
+  return $dependencies;
+}
+
+/**
+ * Update webform_submissions.confirmed based on activity data.
+ */
+function campaignion_activity_update_10() {
+  // Nothing to do if the webform_confirm_email module wasn’t enabled before.
+  if (drupal_get_installed_schema_version('webform_confirm_email') == SCHEMA_UNINSTALLED) {
+    return;
+  }
+  $sql = <<<SQL
+UPDATE {webform_submissions} s
+  INNER JOIN {campaignion_activity_webform} caw USING(nid, sid)
+  INNER JOIN {campaignion_activity} ca USING(activity_id)
+SET s.confirmed=caw.confirmed
+WHERE s.confirmed IS NOT NULL
+SQL;
+  db_query($sql);
+}
+
+/**
  * Remove newsletter activities.
  */
 function campaignion_activity_update_9() {

--- a/campaignion_activity/campaignion_activity.module
+++ b/campaignion_activity/campaignion_activity.module
@@ -30,7 +30,7 @@ function campaignion_activity_campaignion_action_taken($node, Submission $submis
   $activity = WebformSubmission::fromSubmission($submission, [
     'contact_id' => $contact->contact_id,
   ]);
-  $activity->confirmed = $activity->confirmed ?? ($submission->confirmed ? $when : NULL);
+  $activity->confirmed = $submission->confirmed ?? NULL;
 
   if ($payments = $submission->payments ?? NULL) {
     foreach ($payments as $payment) {


### PR DESCRIPTION
With the upcoming version webform_confirm_email has a confirmed timestamp instead of just a boolean value. This can be used by campaignion_activity.

Since webform_confirm_email didn’t have timestamps for this before and campaignion_activity did, we have the more accurate data to update the timestamps in the activity tables.

The update hooks are bit complicated because webform_confirm_email is an optional dependency and we only want the hook to run if webform_confirm_email was updated recently.