### PR TITLE
Amend submission expiry to exclude donation_amount from deletion.

### DIFF
--- a/campaignion_expiry/src/SubmissionCron.php
+++ b/campaignion_expiry/src/SubmissionCron.php
@@ -90,15 +90,18 @@ DELETE wsd
 FROM {webform_submitted_data} wsd
   INNER JOIN {webform_component} wc USING(nid, cid)
   INNER JOIN {tmp_pseudo_addresses} USING(nid, sid)
-WHERE wc.form_key<>'email'
+WHERE wc.form_key NOT IN ('email', 'donation_amount')
 SQL;
     db_query($sql_delete_submitted_data);
 
     $sql_anonymize_email = <<<SQL
 UPDATE {webform_submitted_data} wsd
+  INNER JOIN {webform_component} wc USING(nid, cid)
   INNER JOIN {tmp_pseudo_addresses} t USING(nid, sid)
 SET wsd.data=t.email
-WHERE wsd.data NOT LIKE '%@deleted' AND wsd.data NOT LIKE '%@form-submission';
+WHERE wsd.data NOT LIKE '%@deleted'
+  AND wsd.data NOT LIKE '%@form-submission'
+  AND wc.form_key ='email';
 SQL;
     db_query($sql_anonymize_email);
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/qFl8cUrH/2720-7990-refco-data-anonymisation-and-income-tracking-meters)
If submission expiry is activated, the progress bar on donation forms reduces by the deleted donation amounts.
To circumvent this the donation_amount is exempt from the expiry. 