### PR TITLE
[webform widget] remove X-Frame-Options header

### DIFF
--- a/campaignion_webform_widget/campaignion_webform_widget.module
+++ b/campaignion_webform_widget/campaignion_webform_widget.module
@@ -197,8 +197,8 @@ function campaignion_webform_widget_preprocess_page(&$vars) {
     if (campaignion_webform_widget_context_is_active($context)) {
       $vars['theme_hook_suggestions'][] = "page__$context";
       drupal_add_js(drupal_get_path('module', 'campaignion_webform_widget') . '/js/widget.js');
-      // Override the X-Frame-Options header for this request.
-      drupal_add_http_header('X-Frame-Options', 'allowall');
+      // Remove the X-Frame-Options header for this request.
+      remove_header('X-Frame-Options');
     }
   }
 }


### PR DESCRIPTION
Better to remove the header then setting it to an invalid value.

A `Content-Security-Policy` header should be set instead, e.g. by using the [campaignion_content_security_policy](https://github.com/moreonion/campaignion/tree/7.x-2.x/campaignion_content_security_policy) module.