### PR TITLE
[email_to_target] add another newline to the default header

### DIFF
--- a/campaignion_email_to_target/messages_app/test/unit/fixtures/initial-data.js
+++ b/campaignion_email_to_target/messages_app/test/unit/fixtures/initial-data.js
@@ -53,7 +53,7 @@ export default {
       'urlLabel': '',
       'message': {
         'subject': '',
-        'header': 'Dear [email-to-target:salutation],\n',
+        'header': 'Dear [email-to-target:salutation],\n\n',
         'footer': '\n\nYours sincerely,\n[submission:values:first_name] [submission:values:last_name]\n[submission:values:street_address]\n[submission:values:postcode]',
         'body': ''
       }

--- a/campaignion_email_to_target/src/MessageEndpoint.php
+++ b/campaignion_email_to_target/src/MessageEndpoint.php
@@ -128,7 +128,7 @@ class MessageEndpoint {
     if (!$templates) {
       $templates[] = new MessageTemplate([
         'subject' => '',
-        'header' => t("Dear [email-to-target:salutation],\n"),
+        'header' => t("Dear [email-to-target:salutation],\n\n"),
         'message' => '',
         'footer' => t("\n\nYours sincerely,\n[submission:values:first_name] [submission:values:last_name]\n[submission:values:street_address]\n[submission:values:postcode]"),
       ]);


### PR DESCRIPTION
Two line breaks are needed in order to create space before the message in plain text emails.