### PR TITLE
Draft: Mailchimp compressed responses

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters_mailchimp/src/Rest/ApiError.php
+++ b/campaignion_newsletters/campaignion_newsletters_mailchimp/src/Rest/ApiError.php
@@ -14,7 +14,13 @@ class ApiError extends _ApiError {
    * Create an API-Error instance from a HttpError exception.
    */
   public static function fromHttpError(HttpError $e, $verb, $path) {
-    if ($data = drupal_json_decode($e->result->data)) {
+    $json_data = $e->result->data;
+    if (isset($e->result->headers['content-encoding'])) {
+      if ($e->result->headers['content-encoding'] == 'gzip') {
+        $json_data = gzdecode($e->result->data);
+      }
+    }
+    if ($data = drupal_json_decode($json_data)) {
       $code = $e->getCode();
       $msg = "Got @code for %verb %path: @title - @detail %errors";
       $vars = [


### PR DESCRIPTION
Mailchimp can send responses compressed (with `gzip`).

`ApiError` needs to deal with it to properly recognize error cases. If it fails recognizing them, working the queue will eventually block due to not cleaned up, persistently erroring queue items.