### PR TITLE
activity: Handle submissions without payment objects

### DIFF
--- a/campaignion_activity/campaignion_activity.module
+++ b/campaignion_activity/campaignion_activity.module
@@ -32,13 +32,11 @@ function campaignion_activity_campaignion_action_taken($node, Submission $submis
   ]);
   $activity->confirmed = $submission->confirmed ?? NULL;
 
-  if ($payments = $submission->payments ?? NULL) {
-    foreach ($payments as $payment) {
-      if (payment_status_is_or_has_ancestor($payment->getStatus()->status, PAYMENT_STATUS_SUCCESS)) {
-        $activity = new WebformPayment($activity);
-        $activity->pid = $payment->pid;
-        break;
-      }
+  foreach (array_filter($submission->payments ?? []) as $payment) {
+    if (payment_status_is_or_has_ancestor($payment->getStatus()->status, PAYMENT_STATUS_SUCCESS)) {
+      $activity = new WebformPayment($activity);
+      $activity->pid = $payment->pid;
+      break;
     }
   }
   $activity->save();


### PR DESCRIPTION
$submission->payments might contain NULL items for incomplete form submissions. The activity import should still proceed without errors.