### PR TITLE
feat(newsletters): Unsubscribe unknown independent of all lists, remove welcome emails

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters.module
+++ b/campaignion_newsletters/campaignion_newsletters.module
@@ -101,7 +101,6 @@ function campaignion_webform_component_defaults_alter(&$component, $type) {
   $component['extra'] += [
     'lists' => [],
     'opt_in_implied' => 1,
-    'send_welcome' => 0,
     'optout_all_lists' => TRUE,
   ];
 }
@@ -153,22 +152,6 @@ function campaignion_newsletters_form_webform_component_edit_form_alter(&$elemen
       1 => t('Included in this form: This form includes a double-opt-in process no further action is needed'),
     ],
     '#parents' => ['extra', 'opt_in_implied'],
-  ];
-
-  $element['list_management']['welcome'] = [
-    '#type' => 'container',
-    '#attributes' => ['class' => ['form-item']],
-  ];
-  $element['list_management']['welcome']['label'] = [
-    '#theme' => 'form_element_label',
-    '#title' => t('Welcome email'),
-    '#title_display' => 'before',
-  ];
-  $element['list_management']['welcome']['enabled'] = [
-    '#type' => 'checkbox',
-    '#title' => t('Send a welcome email (for new subscribers).'),
-    '#default_value' => !empty($component['extra']['send_welcome']),
-    '#parents' => ['extra', 'send_welcome'],
   ];
 
   $element['behavior']['optout_all_lists'] = [

--- a/campaignion_newsletters/campaignion_newsletters.variable.inc
+++ b/campaignion_newsletters/campaignion_newsletters.variable.inc
@@ -25,7 +25,7 @@ function campaignion_newsletters_variable_info($options) {
   ];
   $v['campaignion_newsletters_unsubscribe_unknown'] = [
     'title' => t('Try removing unknown subscriptions.', [], $options),
-    'description' => t('When unsubscribing from all lists try to unsubscribe from all lists instead of just those that we have subscriptions for.', [], $options),
+    'description' => t('Send unsubscribes even if we don’t have subscriptions on record.', [], $options),
     'type' => 'boolean',
     'default' => FALSE,
     'localize' => FALSE,

--- a/campaignion_newsletters/src/QueueItem.php
+++ b/campaignion_newsletters/src/QueueItem.php
@@ -223,13 +223,6 @@ SQL;
   }
 
   /**
-   * Check whether a welcome email should besent.
-   */
-  public function welcome() {
-    return !empty($this->args['send_welcome']);
-  }
-
-  /**
    * Trigger the queued action on the list’s provider.
    *
    * @throws \Drupal\campaignion_newsletters\ApiError

--- a/campaignion_newsletters/src/Subscription.php
+++ b/campaignion_newsletters/src/Subscription.php
@@ -197,10 +197,8 @@ class Subscription extends Model {
    * Calculate the arguments for a queue item.
    */
   public function queueItemArgs() {
-    $args['send_welcome'] = FALSE;
     $args['send_optin'] = FALSE;
     foreach ($this->components as $component) {
-      $args['send_welcome'] = $args['send_welcome'] || !empty($component['extra']['send_welcome']);
       $args['send_optin'] = $args['send_optin'] || empty($component['extra']['opt_in_implied']);
     }
     return $args;

--- a/campaignion_newsletters/tests/ComponentTest.php
+++ b/campaignion_newsletters/tests/ComponentTest.php
@@ -93,6 +93,18 @@ class ComponentTest extends \DrupalUnitTestCase {
     foreach ($subscriptions as $s) {
       $this->assertTrue($s->delete);
     }
+
+    $component['extra']['lists'] = [3 => 3];
+    $component['extra']['optout_all_lists'] = FALSE;
+    $c = new Component($component, TRUE);
+    $c->setAllListIds([1, 2, 3]);
+    $subscriptions = $c->getSubscriptions($e, $this->submission);
+    $this->assertEquals([3], array_map(function ($s) {
+      return $s->list_id;
+    }, $subscriptions));
+    foreach ($subscriptions as $s) {
+      $this->assertTrue($s->delete);
+    }
   }
 
   /**

--- a/campaignion_newsletters/tests/SubscriptionTest.php
+++ b/campaignion_newsletters/tests/SubscriptionTest.php
@@ -111,8 +111,8 @@ class SubscriptionTest extends \DrupalWebTestCase {
    * Test merging subscriptions.
    */
   public function testMerge() {
-    $c1 = ['cid' => 1, 'extra' => ['opt_in_implied' => 1, 'send_welcome' => 1]];
-    $c2 = ['cid' => 2, 'extra' => ['opt_in_implied' => 0, 'send_welcome' => 0]];
+    $c1 = ['cid' => 1, 'extra' => ['opt_in_implied' => 1]];
+    $c2 = ['cid' => 2, 'extra' => ['opt_in_implied' => 0]];
     $email = 'merge@test.com';
     $s1 = Subscription::byData(1, $email, [
       'fingerprint' => 'fingerprint1',
@@ -129,7 +129,6 @@ class SubscriptionTest extends \DrupalWebTestCase {
     $this->assertEqual($s1->fingerprint, '');
     // TRUE wins.
     $args = $s1->queueItemArgs();
-    $this->assertTrue($args['send_welcome']);
     $this->assertTrue($args['send_optin']);
   }
 }


### PR DESCRIPTION
Make it possible to use the “unsubscribe unknown” setting independently from the “all lists“ setting on the component.