### PR TITLE
Upgrade to jQuery 3

### DIFF
--- a/campaignion_bar/js/campaignion_bar.js
+++ b/campaignion_bar/js/campaignion_bar.js
@@ -28,7 +28,7 @@
 
           // call window.load (ie. when all images are loaded) to set
           // the correct calculated sizes
-          $(window).load(function () {
+          $(window).on('load', function () {
             setTimeout(Drupal.aeBar.setDimensions, 1);
           });
         });


### PR DESCRIPTION
This only cares about functions that have been removed between in jQuery 3. It does not deal with deprecations.