### PR TITLE
fix(e2t): Quote name-part of the to-address

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
         ln -s $REPO $ROOT/sites/all/modules/module_under_test
         cd $ROOT
         curl https://www.drupal.org/files/issues/1891356-drupal_static_reset-on-module-changes-30-D7.patch | patch -p1
-        drush dl --cache-duration-releasexml=0 little_helpers-2.0-alpha12
+        drush dl --cache-duration-releasexml=0 addressfield-1.3 chr-1.9 context-3.12 ctools-1.21 currency-2.6 date-2.14 entity-1.11 entityreference-1.9 features-2.15 field_collection-1.2 field_type_language-1.0 file_entity-2.40 form_builder-2.0-alpha8 i18n-1.35 jquery_update-4.1 libraries-2.5 little_helpers-2.0-alpha12 media-2.30 options_element-1.12 oowizard-1.0-alpha3 payment-1.20 payment_context-1.0 payment_recurrence-1.0-alpha2 paypal_payment-1.5 polling-1.1 postal_code_validation-1.7 psr0-1.6 redhen-1.13 references-2.4 save_draft-1.4 select2-1.0 strongarm-2.0 token-1.9 ultimate_cron-2.11 uuid-1.3 uuid_features-1.0-rc2 variable-2.5 views-3.29 webform-4.27 webform_ajax-2.0 webform_confirm_email-2.20 webform_country_list-1.6 webform_paymethod_select-2.11 webform_template-4.0 webform_validation-1.18
         drush --yes pm-enable campaignion_test
     - name: Run phpunit tests
       run: UPAL_ROOT=$ROOT UPAL_WEB_URL=http://127.0.0.1 XDEBUG_MODE=coverage phpunit --bootstrap=$COMPOSER_HOME/vendor/torotil/upal/bootstrap.php --coverage-clover=coverage.xml .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       id: composer-cache
       run: |
         echo "::set-output name=dir::$(composer config cache-files-dir)"
-    - uses: actions/cache@v2
+    - uses: actions/cache/restore@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-
@@ -46,6 +46,11 @@ jobs:
         mkdir -p $COMPOSER_HOME
         cd $COMPOSER_HOME
         composer require drush/drush:8.3.* phpunit/phpunit:^8 torotil/upal:2.0.0-RC1
+    - name: Cache composer packages
+      id: composer-cache-write
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ runner.os }}-composer-
     - name: Bootstrap drupal
       run: |
         php -d sendmail_path=`which true` $COMPOSER_HOME/vendor/bin/drush.php --yes core-quick-drupal --core=drupal-7.82 --profile=testing --no-server --db-url=mysql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@127.0.0.1:3306/${{ env.DB_DATABASE }} --root=$ROOT

--- a/campaignion_email_to_target/src/Message.php
+++ b/campaignion_email_to_target/src/Message.php
@@ -47,14 +47,10 @@ class Message extends MessageTemplateInstance {
   /**
    * Quote strings for use in address headers.
    *
-   * Quote backslashes and any double quotation marks by prepending a
-   * backslash.
-   * See https://tools.ietf.org/html/rfc5322#section-3.2.4
+   * Encode UTF-8 characters as needed then quote double quotes.
    */
-  protected function quoteMail($string) {
-    $quoted1 = preg_replace("/\\\\/", "\\\\\\\\", $string);
-    $quoted2 = preg_replace('/"/', '\\\\"', $quoted1);
-    return $quoted2;
+  protected function quoteMail($string): string {
+    return addcslashes(mb_encode_mimeheader($string, 'UTF-8', 'Q'), '"\\');
   }
 
   /**

--- a/campaignion_email_to_target/tests/MessageTest.php
+++ b/campaignion_email_to_target/tests/MessageTest.php
@@ -112,11 +112,11 @@ class MessageTest extends \DrupalUnitTestCase {
     $data = [
       'fromName' => 'I have, a comma but am no "addr-list"',
       'fromAddress' => 'from@example.com',
-      'toName' => ' to \ be " quoted',
+      'toName' => ' to \ be " quoted Ümlaut',
       'toAddress' => 'to@example.com',
     ];
     $m = new Message($data);
-    $this->assertEqual('"to \\\\ be \" quoted" <to@example.com>', $m->to());
+    $this->assertEqual('"to \\\\ be \" quoted =?UTF-8?Q?=C3=9Cmlaut?=" <to@example.com>', $m->to());
     $this->assertEqual('"I have, a comma but am no \"addr-list\"" <from@example.com>', $m->from());
   }
 


### PR DESCRIPTION
While Drupal encodes all headers (including From) it doesn’t do that for the To-header.

This uses PHP-builtin functions for encoding non-ascii characters as opposed to Drupal’s mime_header_encode() which encodes the entire string.