### PR TITLE
fix(dotmailer): Deal with non-URL-safe characters in credentials

### DIFF
--- a/campaignion_newsletters/campaignion_newsletters_dotmailer/src/Api/Client.php
+++ b/campaignion_newsletters/campaignion_newsletters_dotmailer/src/Api/Client.php
@@ -10,8 +10,9 @@ use \Drupal\campaignion_newsletters\ApiError;
 
 class Client extends _Client {
   public function __construct($username, $password) {
-    $endpoint = "https://$username:$password@api.dotmailer.com/v2";
-    parent::__construct($endpoint);
+    $endpoint = "https://api.dotmailer.com/v2";
+    $options['headers']['Authorization'] = 'Basic ' . base64_encode("$username:$password");
+    parent::__construct($endpoint, $options);
   }
 
   protected function send($path, array $query = [], $data = NULL, array $options = []) {


### PR DESCRIPTION
Passing username and password as part of the URL assumes they don’t use special characters. Pass the credentials as Authorization header instead.