### PR TITLE
feat(email_to_target): Use org based filter instead of groups

### DIFF
--- a/campaignion_email_to_target/campaignion_email_to_target.variable.inc
+++ b/campaignion_email_to_target/campaignion_email_to_target.variable.inc
@@ -16,13 +16,6 @@ function campaignion_email_to_target_variable_info($options) {
     'default' => '',
     'localize' => FALSE,
   ];
-  $v['campaignion_email_to_target_dataset_query'] = [
-    'title' => t('Dataset GET-query string'),
-    'description' => t('Default query parameters for the dataset listing including the leading question mark.'),
-    'type' => 'string',
-    'default' => '',
-    'localize' => FALSE,
-  ];
   $v['campaignion_email_to_target_mp_datasets'] = [
     'title' => t('MP datasets'),
     'description' => t('List of dataset keys for all datasets that are considered MP datasets'),

--- a/campaignion_email_to_target/src/Wizard/TargetStep.php
+++ b/campaignion_email_to_target/src/Wizard/TargetStep.php
@@ -115,8 +115,8 @@ class TargetStep extends WizardStep {
       'url' => $this->api->getEndpoint(),
       'token' => $this->api->getAccessToken(),
     ];
-    $settings['datasetQuery'] = variable_get_value('campaignion_email_to_target_dataset_query');
     $settings['organization'] = variable_get_value('campaignion_organization');
+    $settings['datasetQuery'] = "?organization={$settings['organization']}";
 
     $settings = ['campaignion_email_to_target' => $settings];
     $dir = drupal_get_path('module', 'campaignion_email_to_target');


### PR DESCRIPTION
Groups can now be configured in the apps themselves and don’t need configuration in IST1.